### PR TITLE
MST test coverage (interleaved-ops model spec + validator) + docs overhaul

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,9 @@
 # 0.4.x
 
-- **Content-defined boundary mode (Merkle Search Tree / "prolly" trees)** — opt-in per set via
-  `{:boundary (mst-boundary lzpl)}`. Split points are derived from key hashes (`hasch.fast`,
+- **Content-defined boundary mode (Merkle Search Tree / "prolly" trees)** — _**experimental**_,
+  opt-in per set via `{:boundary (mst-boundary lzpl)}`. The API and on-disk boundary descriptor
+  may still change, and it is not yet hardened for production sync workloads; the default count
+  B-tree is unaffected. Split points are derived from key hashes (`hasch.fast`,
   byte-identical JVM↔cljs) instead of node fill, so the tree is a pure function of its element
   set: the same elements always produce the byte-identical, content-addressed structure
   regardless of `conj`/`disj` order or which platform built it. Aimed at CRDT state sync and

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,38 @@
+# 0.4.x
+
+- **Content-defined boundary mode (Merkle Search Tree / "prolly" trees)** — opt-in per set via
+  `{:boundary (mst-boundary lzpl)}`. Split points are derived from key hashes (`hasch.fast`,
+  byte-identical JVM↔cljs) instead of node fill, so the tree is a pure function of its element
+  set: the same elements always produce the byte-identical, content-addressed structure
+  regardless of `conj`/`disj` order or which platform built it. Aimed at CRDT state sync and
+  cross-replica dedup. Self-describing (the policy rides in the serialized blob and
+  self-restores with no consumer configuration). Forces diff-buffering off and rejects leaf
+  processors — both would break canonical addressing. Implemented on JVM + cljs, including
+  storage-aware durable removal (address-preserving + `markFreed`). See
+  `doc/merkle-search-tree.md`.
+- Pluggable split-decision seam: the historical count B-tree is now the default `CountBoundary`
+  (`IBoundary`) / `PBoundary` policy, byte-identical to before, with the split point factored
+  out so MST (and future policies) plug in. No measurable performance change to the default
+  path (verified by an interleaved criterium A/B against the pre-seam baseline).
+
+The following also shipped in the 0.4 line but were not previously recorded here:
+
+- **Diff buffering** (opt-in, off by default) — on immutable content-addressed storage, brings a
+  content-only commit down to ~1 written object by buffering each unchanged-structure child's
+  diff at the serialization boundary, re-pointing to the child's existing durable address.
+  Gated by `:diff-buf-size` / `-Dpss.diffBufSize`; `0` is byte-identical to baseline. See
+  `doc/diff-buffering.md`.
+- **Subtree counts** — branch nodes carry subtree element counts; `count-slice` counts a range
+  in O(log n) without iterating, and `hasSubtreeCounts()` is an O(1) check before using it.
+- **Rank-based access** — `get-nth` reaches an element by position in O(log n) for
+  percentile/quantile queries (requires a `:measure` with a `weight`).
+- **Aggregate statistics** — an optional monoidal `:measure` (`IMeasure` interface / protocol),
+  maintained incrementally; `measure` and `measure-slice` answer range aggregates (sum, count,
+  min/max, variance, …) in O(log n). Built-in `NumericStatsOps`. See
+  `doc/statistical-queries.md`.
+- **Faster iteration**, plus `lookup` (retrieve the actually-stored key) and `replace`
+  (single-traversal in-place update at the same logical position).
+
 # 0.4.0
 
 - Added `org.replikativ.persistent-sorted-set.fressian` — an **optional** canonical Fressian

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Implementations are provided for both Clojure and ClojureScript.
   reduction that brings a content-only commit on content-addressed storage down to ~1 object.
   See [doc/diff-buffering.md](doc/diff-buffering.md).
 - **[Content-defined boundaries (Merkle Search Tree)](#content-defined-boundaries-merkle-search-tree)**
-  — opt-in *prolly* mode where equal sets are byte-identical trees regardless of history, for
-  CRDT state sync and cross-replica dedup. See
+  — _**experimental**_, opt-in *prolly* mode where equal sets are byte-identical trees regardless
+  of history, for CRDT state sync and cross-replica dedup. See
   [doc/merkle-search-tree.md](doc/merkle-search-tree.md).
 
 Full documentation index: **[doc/README.md](doc/README.md)**.
@@ -344,6 +344,13 @@ drops buffered changes, which is why the default is off. See
 storage contract.
 
 ## Content-defined boundaries (Merkle Search Tree)
+
+> **⚠️ Experimental.** This mode is new and opt-in. Its public API (`mst-boundary`, `:boundary`)
+> and the serialized boundary descriptor may still change, and it has not yet been hardened in
+> production sync workloads — don't rely on the on-disk format for long-lived MST data yet. The
+> cross-platform determinism and `conj`/`disj`/`replace` canonicality are property-tested on both
+> JVM and ClojureScript, but treat the feature as unstable. **The default count B-tree is
+> unaffected and stable.**
 
 By default the tree shape depends on insertion/removal order. **Content-defined boundary mode**
 (a *Merkle Search Tree*, the family informally called *prolly trees*) decides splits from a

--- a/README.md
+++ b/README.md
@@ -1,38 +1,66 @@
-A B-tree based persistent sorted set for Clojure/Script.
+# PersistentSortedSet
 
-PersistentSortedSet supports:
+<p align="center">
+<a href="https://clojurians.slack.com/archives/CB7GJAN0L"><img src="https://badgen.net/badge/-/slack?icon=slack&label"/></a>
+<a href="https://clojars.org/io.replikativ/persistent-sorted-set"><img src="https://img.shields.io/clojars/v/io.replikativ/persistent-sorted-set.svg"/></a>
+<a href="https://circleci.com/gh/replikativ/persistent-sorted-set"><img src="https://circleci.com/gh/replikativ/persistent-sorted-set.svg?style=shield"/></a>
+<a href="https://github.com/replikativ/persistent-sorted-set/tree/main"><img src="https://img.shields.io/github/last-commit/replikativ/persistent-sorted-set/main"/></a>
+</p>
 
-- transients,
-- custom comparators,
-- fast iteration,
-- efficient slices (iterator over a part of the set),
-- efficient `rseq` on slices,
-- `lookup` to retrieve actual stored keys,
-- `replace` for single-traversal key updates at same logical position,
-- durable storage with automatic garbage collection via `markFreed`.
+**A fast, durable B-tree sorted set for Clojure and ClojureScript.**
 
-Almost a drop-in replacement for `clojure.core/sorted-set`, the only difference being this one can’t store `nil`.
+PersistentSortedSet is an almost drop-in replacement for `clojure.core/sorted-set` — a
+persistent, immutable sorted set backed by a B+-tree with structural sharing. Beyond the
+standard set API it adds efficient slicing, transients, custom comparators, lazy durable
+storage on any backend, range statistics, and a content-addressed mode for CRDT sync. The only
+behavioral difference from `clojure.core/sorted-set` is that it can't store `nil`.
 
-Implementations are provided for Clojure and ClojureScript.
+Implementations are provided for both Clojure and ClojureScript.
 
-## Building
+## Key features
 
-```
-export JAVA8_HOME="/Library/Java/JavaVirtualMachines/jdk1.8.0_202.jdk/Contents/Home"
-lein jar
-```
+- **[Drop-in sorted set](#usage)** — `sorted-set`, `sorted-set-by`, `conj`, `disj`,
+  `contains?`, custom comparators, transients.
+- **[Efficient slices & seeking](#slices-and-seeking)** — `slice`/`rslice` iterate any
+  sub-range, with `rseq` and `seek` to reposition an open iterator in O(log n).
+- **[`lookup` & `replace`](#lookup-and-replace)** — retrieve the actual stored key, or update a
+  key in place at the same logical position in a single traversal.
+- **[Durable storage](#durability)** — store the tree to disk/DB/object-storage through a small
+  `IStorage` interface; restore lazily, loading only the nodes an operation touches. Automatic
+  GC of unreachable nodes via `markFreed`. Async storage on ClojureScript.
+- **[Canonical serialization](#serialization)** — optional Fressian read/write handlers so
+  konserve/kabel-backed consumers share one wire form; self-describing, content-addressed
+  nodes. See [doc/serialization.md](doc/serialization.md).
+- **[Range statistics](#range-counting-rank-access-and-aggregate-statistics)** — subtree counts
+  give O(log n) `count-slice`; a monoidal `:measure` gives O(log n) rank/percentile access
+  (`get-nth`) and range aggregates (`measure`, `measure-slice`). See
+  [doc/statistical-queries.md](doc/statistical-queries.md).
+- **[Diff buffering](#diff-buffering-write-amplification)** — opt-in write-amplification
+  reduction that brings a content-only commit on content-addressed storage down to ~1 object.
+  See [doc/diff-buffering.md](doc/diff-buffering.md).
+- **[Content-defined boundaries (Merkle Search Tree)](#content-defined-boundaries-merkle-search-tree)**
+  — opt-in *prolly* mode where equal sets are byte-identical trees regardless of history, for
+  CRDT state sync and cross-replica dedup. See
+  [doc/merkle-search-tree.md](doc/merkle-search-tree.md).
 
-## Usage
+Full documentation index: **[doc/README.md](doc/README.md)**.
 
-Dependency:
+## Installation
+
+[![Clojars Project](https://img.shields.io/clojars/v/io.replikativ/persistent-sorted-set.svg)](https://clojars.org/io.replikativ/persistent-sorted-set)
 
 ```clj
-[io.replikativ/persistent-sorted-set "0.3.100"]
+;; deps.edn
+io.replikativ/persistent-sorted-set {:mvn/version "LATEST"}
+
+;; Leiningen
+[io.replikativ/persistent-sorted-set "LATEST"]
 ```
 
-The version follows the pattern `0.3.{commit-count}` and is automatically incremented with each commit.
+The version follows the pattern `0.4.{commit-count}` and is incremented automatically on each
+commit; the Clojars badge above shows the current release.
 
-Code:
+## Usage
 
 ```clj
 (require '[org.replikativ.persistent-sorted-set :as set])
@@ -52,6 +80,15 @@ Code:
     (contains? 3))
 ;=> true
 
+(set/sorted-set-by > 1 2 3)
+;=> #{3 2 1}
+```
+
+### Slices and seeking
+
+`slice` and `rslice` return a lazy seq over a sub-range, iterating only the nodes they need:
+
+```clj
 (-> (apply set/sorted-set (range 10000))
     (set/slice 5000 5010))
 ;=> (5000 5001 5002 5003 5004 5005 5006 5007 5008 5009 5010)
@@ -59,11 +96,30 @@ Code:
 (-> (apply set/sorted-set (range 10000))
     (set/rslice 5010 5000))
 ;=> (5010 5009 5008 5007 5006 5005 5004 5003 5002 5001 5000)
+```
 
-(set/sorted-set-by > 1 2 3)
-;=> #{3 2 1}
+`seek` repositions an existing iterator forward in O(log n) without re-traversing from the
+start — useful for merge-join-style consumption:
 
-;; lookup returns the actual stored key
+```clj
+(-> (seq (into (set/sorted-set) (range 10)))
+    (set/seek 5))
+;=> (5 6 7 8 9)
+
+(-> (into (set/sorted-set) (range 100))
+    (set/rslice 75 25)
+    (set/seek 60)
+    (set/seek 30))
+;=> (30 29 28 27 26 25)
+```
+
+### lookup and replace
+
+`lookup` returns the *actual stored key* (handy when keys carry payload compared by a partial
+comparator); `replace` updates a key in place when the old and new keys compare equal, in a
+single traversal:
+
+```clj
 (-> (set/sorted-set 1 2 3 4)
     (set/lookup 3))
 ;=> 3
@@ -72,58 +128,18 @@ Code:
     (set/lookup 99 :not-found))
 ;=> :not-found
 
-;; replace updates a key at the same logical position
-;; (old-key and new-key must compare equal)
+;; replace updates a key at the same logical position (old and new must compare equal)
 (defn cmp-by-id [[id1 _] [id2 _]] (compare id1 id2))
 
 (-> (set/sorted-set-by cmp-by-id [1 :old] [2 :old] [3 :old])
     (set/replace [2 :old] [2 :new]))
 ;=> #{[1 :old] [2 :new] [3 :old]}
 ```
-One can also efficiently seek on the iterators.
-
-```clj
-(-> (seq (into (set/sorted-set) (range 10)))
-    (set/seek 5))
-;; => (5 6 7 8 9)
-
-(-> (into (set/sorted-set) (range 100))
-    (set/rslice 75 25)
-    (set/seek 60)
-    (set/seek 30))
-;; => (30 29 28 27 26 25)
-```
-
-## Development
-
-### CI/CD Pipeline
-
-This project uses CircleCI for continuous integration and deployment:
-
-- **Automated Testing**: Both Clojure and ClojureScript tests run on every commit
-- **Code Formatting**: Automatic formatting checks with cljfmt ensure consistent code style
-- **Versioning**: Releases follow semantic versioning `0.3.{commit-count}`, automatically calculated
-- **Deployment**: On the `main` branch, successful builds are automatically:
-  - Deployed to [Clojars](https://clojars.org/io.replikativ/persistent-sorted-set)
-  - Released to [GitHub](https://github.com/replikativ/persistent-sorted-set/releases)
-
-### Code Formatting
-
-To ensure consistent code style for easier PR review:
-
-```bash
-# Check formatting
-clj -M:format
-
-# Auto-fix formatting issues
-clj -M:ffix
-```
 
 ## Durability
 
-Clojure version allows efficient storage of Persistent Sorted Set on disk/DB/anywhere.
-
-To do that, implement `IStorage` interface:
+The Clojure version can store a PersistentSortedSet on disk / in a DB / anywhere, and restore
+it lazily. Implement the `IStorage` interface:
 
 ```clojure
 (defrecord Storage [*storage]
@@ -165,74 +181,49 @@ To do that, implement `IStorage` interface:
     nil))
 ```
 
-Storing Persistent Sorted Set works per node. This will save each node once:
+Storing works per node, writing each node once:
 
 ```clojure
-(def set
-  (into (set/sorted-set) (range 1000000)))
-
-(def storage
-  (Storage. (atom {})))
-
-(def root
-  (set/store set storage))
+(def set     (into (set/sorted-set) (range 1000000)))
+(def storage (Storage. (atom {})))
+(def root    (set/store set storage))
 ```
 
-If you try to store once again, no store operations will be issued:
+Storing again issues no writes — the root is unchanged:
 
 ```clojure
-(assert
-  (= root
-    (set/store set storage)))
+(assert (= root (set/store set storage)))
 ```
 
-If you modify set and store new one, only nodes that were changed will be stored. For a tree of depth 3, it’s usually just \~3 nodes. The root will be new, though:
+Modify and store again, and only the changed nodes are written. For a tree of depth 3 that's
+usually ~3 nodes; the root is always new:
 
 ```clojure
-(def set2
-  (into set [-1 -2 -3]))
-
-(assert
-  (not= root
-    (set/store set2 storage)))
+(def set2 (into set [-1 -2 -3]))
+(assert (not= root (set/store set2 storage)))
 ```
 
-Finally, one can construct a new set from its stored snapshot. You’ll need address for that:
+Reconstruct a set from a stored snapshot using its root address:
 
 ```clojure
-(def set-lazy
-  (set/restore root storage))
+(def set-lazy (set/restore root storage))
 ```
 
-Restore operation is lazy. By default it won’t do anything, but when you start accessing returned set, `IStorage::restore` operations will be issued and part of the set will be reconstructed in memory. Only nodes needed for a particular operation will be loaded.
-
-E.g. this will load \~3 nodes for a set of depth 3:
-
-```clojure
-(first set-lazy)
-```
-
-This will load \~50 nodes on default settings:
+`restore` is **lazy**: nothing loads until you access the set, and then only the nodes a
+particular operation needs are fetched via `IStorage::restore`. `(first set-lazy)` loads ~3
+nodes for a depth-3 tree; `(take 5000 set-lazy)` loads ~50 on default settings. Every operation
+that works on an in-memory set works transparently on a lazy one, which can live arbitrarily
+long without being fully realized:
 
 ```clojure
-(take 5000 set-lazy)
-```
-
-Internally Persistent Sorted Set does not caches returned nodes, so don’t be surprised if subsequent `first` loads the same nodes again. One must implement cache inside IStorage implementation for efficient retrieval of already loaded nodes. Also see `IStorage::accessed` for access stats, e.g. for LRU.
-
-Any operation that can be done on in-memory PSS can be done on a lazy one, too. It will fetch required nodes when needed, completely transparently for the user. Lazy PSS can exist arbitrary long without ever being fully realized in memory:
-
-```clojure
-(def set3
-  (conj set-lazy [-1 -2 -3]))
-
-(def set4
-  (disj set-lazy [4 5 6 7 8]))
-
+(conj set-lazy [-1 -2 -3])
+(disj set-lazy [4 5 6 7 8])
 (contains? set-lazy 5000)
 ```
 
-Last piece of the puzzle: `set/walk-addresses`. Use it to check which nodes are actually in use by current PSS and optionally clean up garbage in your storage that is not referenced by it anymore:
+PSS does not cache restored nodes itself — implement caching inside your `IStorage` (see
+`IStorage::accessed` for LRU stats). Use `walk-addresses` to enumerate the nodes a set
+actually references, e.g. to GC unreferenced objects from your storage:
 
 ```clojure
 (let [*alive-addresses (volatile! [])]
@@ -240,22 +231,103 @@ Last piece of the puzzle: `set/walk-addresses`. Use it to check which nodes are 
   @*alive-addresses)
 ```
 
-See [test_storage.clj](test-clojure/org/replikativ/persistent_sorted_set/test_storage.clj) for more examples.
+See [test-clojure/org/replikativ/persistent_sorted_set/test/storage.clj](test-clojure/org/replikativ/persistent_sorted_set/test/storage.clj)
+for more examples.
 
-### ClojureScript Durability
+### ClojureScript durability
 
-ClojureScript also supports durable storage with async operations. The `IStorage` interface works the same way, but `store` and `restore` methods return promises/async values instead of direct values. This allows integration with IndexedDB, remote storage APIs, and other async storage backends.
+ClojureScript also supports durable storage. The `IStorage` interface works the same way, but
+`store`/`restore` return promises/async values, so it integrates with IndexedDB, remote storage
+APIs, and other async backends. Async-aware operations take a `:sync?` option.
 
-## Write amplification (diff buffering)
+## Serialization
+
+For consumers that share a wire format (datahike, yggdrasil, proximum, stratum), the
+`org.replikativ.persistent-sorted-set.fressian` namespace provides an **optional, canonical**
+Fressian read/write handler set for PSS nodes (`pss/leaf`, `pss/branch`) and roots (`pss/set`),
+on both JVM (`clojure.data.fressian`) and ClojureScript (`fress`). Nodes are self-describing —
+`:branching-factor`, `:diff-buf-size`, `:ref-type`, and the content-defined boundary descriptor
+ride in the blob — so a single store can hold a mix of settings and round-trip losslessly. The
+non-serializable bits (live `IStorage`, comparator, measure-ops) resolve at read time via
+consumer-supplied resolvers or id-keyed registries. `data.fressian` is a `provided` dependency.
+
+See [doc/serialization.md](doc/serialization.md).
+
+## Range counting, rank access, and aggregate statistics
+
+Branch nodes carry subtree counts, and an optional monoidal `:measure` lets the tree answer
+range aggregates and rank queries in O(log n) without iterating. See
+[doc/statistical-queries.md](doc/statistical-queries.md) for the full model.
+
+### Range counting
+
+Count elements in a range without iterating through them — O(log n) via subtree counts:
+
+```clj
+(def s (into (set/sorted-set) (range 10000)))
+
+(set/count-slice s 1000 2000)   ;=> 1001   ; [1000, 2000]
+(set/count-slice s nil 500)     ;=> 501    ; .. to 500
+(set/count-slice s 9000 nil)    ;=> 1000   ; 9000 ..
+(set/count-slice s 1000 2000 my-comparator)
+```
+
+### Rank-based access (`get-nth`)
+
+Access elements by position (rank) in O(log n), enabling percentile/quantile queries. Requires
+a `:measure` with a `weight` implementation; the built-in `NumericStatsOps` uses count as
+weight (each element weight 1):
+
+```clj
+(def s (into (set/sorted-set* {:measure (NumericStatsOps.)}) (range 1000)))
+
+(set/get-nth s 500)   ;=> [500 0]   ; [value local-offset]
+(set/get-nth s 950)   ;=> [950 0]
+
+(defn percentile [s p]
+  (let [n (count s), rank (long (* n p))]
+    (first (set/get-nth s rank))))
+
+(percentile s 0.5)    ;=> 500   (median)
+(percentile s 0.95)   ;=> 950   (95th percentile)
+```
+
+`get-nth` returns `[entry local-offset]` (`local-offset` supports weighted statistics where an
+entry represents multiple elements), or `nil` if the rank is out of bounds. On ClojureScript
+the same API is available via `org.replikativ.persistent-sorted-set.impl.numeric-stats`, in
+both sync and async (`:sync?`) modes.
+
+### Aggregate statistics
+
+A `:measure` maintains an aggregate incrementally as elements are added/removed, giving O(log n)
+sum/count/min/max/variance over any range. The built-in numeric measure:
+
+```clj
+(import '[org.replikativ.persistent_sorted_set NumericStatsOps])
+
+(def s (into (set/sorted-set* {:measure (NumericStatsOps.)}) [1 2 3 4 5]))
+
+(set/measure s)         ;=> NumericStats{count=5, sum=15.0, min=1, max=5, ...}
+(set/measure-slice s 2 4) ;=> NumericStats{count=3, sum=9.0, min=2, max=4, ...}
+```
+
+`NumericStats` exposes `count`, `sum`, `sumSq`, `min`, `max`, plus derived `mean()`,
+`variance()`, and `stdDev()`. To implement your own, provide a **monoid** (identity +
+associative merge) via the `IMeasure` interface (JVM) or `IMeasure` protocol (ClojureScript,
+`org.replikativ.persistent-sorted-set.impl.measure`). Non-invertible aggregates like min/max
+receive a `recompute` supplier in `remove` for the case where a removed element changes the
+result. Full interface, custom examples, and the ClojureScript protocol are in
+[doc/statistical-queries.md](doc/statistical-queries.md).
+
+## Diff buffering (write amplification)
 
 On immutable, content-addressed storage (e.g. konserve on S3/GCS), each `store` of a node is a
 new object, and a commit normally rewrites the whole root→leaf path it touched (`≈ depth+1`
-objects). Where each `PUT` dominates cost/latency, **diff buffering** brings a content-only
-commit down to **~1 object per commit**: the in-memory tree stays an ordinary B-tree, and at
-the serialization boundary a rewritten branch buffers each unchanged-structure child's *diff*
-(plus an aggregate snapshot) into its own object, re-pointing to the child's existing durable
-address instead of rewriting it. Reads are unaffected (the diff is projected back lazily on
-descent, once per node). Queries, counts, ranks, and measures all work unchanged.
+objects). Where each `PUT` dominates cost, **diff buffering** brings a content-only commit down
+to **~1 object**: the in-memory tree stays an ordinary B-tree, and at the serialization
+boundary a rewritten branch buffers each unchanged-structure child's *diff* (plus an aggregate
+snapshot) into its own object, re-pointing to the child's existing durable address instead of
+rewriting it. Reads, queries, counts, and measures are unaffected.
 
 It is **off by default** and gated by a per-node budget; `0` is byte-identical to baseline.
 
@@ -265,285 +337,134 @@ It is **off by default** and gated by a per-node budget; `0` is byte-identical t
 ;; or globally via the JVM system property -Dpss.diffBufSize=256
 ```
 
-**Important:** enabling it requires an `IStorage` implementation that serializes and restores
-the per-child slots (`Branch.slotsForStorage` / reconstructing `_slots`). A storage that
-ignores them will silently drop buffered changes on write — which is why the default is off.
+Enabling it requires an `IStorage` that serializes and restores the per-child slots
+(`Branch.slotsForStorage` / reconstructing `_slots`); a storage that ignores them silently
+drops buffered changes, which is why the default is off. See
+[doc/diff-buffering.md](doc/diff-buffering.md) for the model, invariants, on-disk format, and
+storage contract.
 
-See [doc/diff-buffering.md](doc/diff-buffering.md) for the model, invariants, on-disk format,
-and the storage contract.
+## Content-defined boundaries (Merkle Search Tree)
 
-## Efficient Range Counting
+By default the tree shape depends on insertion/removal order. **Content-defined boundary mode**
+(a *Merkle Search Tree*, the family informally called *prolly trees*) decides splits from a
+deterministic hash of the keys, so the tree becomes a pure function of its contents:
 
-Count elements in a range without iterating through them:
+> Same elements ⇒ byte-identical tree — regardless of `conj`/`disj` order, bulk vs incremental
+> construction, or which JVM/JS peer built it.
 
-```clj
-(def s (into (set/sorted-set) (range 10000)))
+This is opt-in per set and the default count B-tree is unaffected. It exists for
+content-addressed **CRDT state sync and dedup**: converged replicas share nodes, so syncing
+ships zero objects and idempotence is an O(1) root-hash comparison.
 
-;; Count elements in [1000, 2000]
-(set/count-slice s 1000 2000)
-;=> 1001
+```clojure
+(require '[org.replikativ.persistent-sorted-set.boundary :as b])
 
-;; Count from beginning to 500
-(set/count-slice s nil 500)
-;=> 501
-
-;; Count from 9000 to end
-(set/count-slice s 9000 nil)
-;=> 1000
-
-;; Use custom comparator
-(set/count-slice s 1000 2000 my-comparator)
+;; lzpl = leading-zeros per level; sets target fanout (avg node ≈ 2^lzpl keys)
+(def s (into (set/sorted-set* {:boundary (b/mst-boundary 5)})
+             (shuffle (range 10000))))
 ```
 
-This uses O(log n) traversal by leveraging subtree counts stored in branch nodes.
-
-## Rank-Based Access (getNth)
-
-Access elements by their position (rank) in O(log n) time, enabling efficient percentile and quantile queries:
-
-```clj
-(def s (into (set/sorted-set* {:measure (NumericStatsOps.)})
-             (range 1000)))
-
-;; Get median (50th percentile) - O(log n)
-(set/get-nth s 500)
-;=> [500 0]  ; [value local-offset]
-
-;; Get 95th percentile
-(set/get-nth s 950)
-;=> [950 0]
-
-;; Helper function for percentiles
-(defn percentile [s p]
-  (let [n (count s)
-        rank (long (* n p))]
-    (first (set/get-nth s rank))))
-
-(percentile s 0.5)   ;=> 500  (median)
-(percentile s 0.95)  ;=> 950  (95th percentile)
-(percentile s 0.25)  ;=> 250  (first quartile)
-```
-
-`get-nth` returns `[entry local-offset]` where `local-offset` is useful for weighted statistics (each entry can represent multiple elements). Returns `nil` if the rank is out of bounds.
-
-**Requirements:** Must configure `:measure` with a `weight` implementation. The built-in `NumericStatsOps` uses count as weight (each element has weight 1).
-
-**Use cases:**
-- **Percentile queries:** Median, quartiles, deciles for statistical analysis
-- **Outlier detection:** Use IQR (Q3 - Q1) with Tukey's fences
-- **Quantile regression:** Fit models at different percentiles
-- **Weighted sampling:** Importance sampling for Monte Carlo methods
-- **CDF evaluation:** Empirical cumulative distribution functions
-
-### ClojureScript
-
-ClojureScript provides the same `get-nth` API:
-
-```cljs
-(require '[org.replikativ.persistent-sorted-set :as set])
-(require '[org.replikativ.persistent-sorted-set.impl.numeric-stats :as nstats])
-
-(def s (into (set/sorted-set* {:measure nstats/numeric-stats-ops})
-             (range 1000)))
-
-(set/get-nth s 500)
-;=> [500 0]
-```
-
-Both sync and async modes are supported via the `:sync?` option.
-
-## Aggregate Statistics
-
-PersistentSortedSet can maintain aggregate statistics that update incrementally as elements are added or removed. This enables O(log n) queries for sum, count, min, max, variance, etc. over any range.
-
-### Using Built-in Numeric Statistics
-
-```clj
-(import '[org.replikativ.persistent_sorted_set NumericStatsOps])
-
-;; Create set with numeric stats tracking
-(def s (into (set/sorted-set* {:measure (NumericStatsOps.)})
-             [1 2 3 4 5]))
-
-;; Get measure for entire set
-(set/measure s)
-;=> NumericStats{count=5, sum=15.0, min=1, max=5, ...}
-
-;; Get measure for a range [2, 4]
-(set/measure-slice s 2 4)
-;=> NumericStats{count=3, sum=9.0, min=2, max=4, ...}
-```
-
-The `NumericStats` object provides `count`, `sum`, `sumSq`, `min`, `max`, plus derived `mean()`, `variance()`, and `stdDev()` methods.
-
-### Implementing Custom Statistics
-
-Statistics must form a **monoid** - they need an identity element and an associative merge operation. Implement the `IMeasure` interface:
-
-```java
-public interface IMeasure<Key, S> {
-    // Identity element: merge(identity, x) == x
-    S identity();
-
-    // Extract measure from a single key
-    S extract(Key key);
-
-    // Associative merge: merge(a, merge(b, c)) == merge(merge(a, b), c)
-    S merge(S s1, S s2);
-
-    // Remove a key's contribution (see below)
-    S remove(S current, Key key, Supplier<S> recompute);
-}
-```
-
-**Example: Counting distinct categories**
-
-```java
-public class CategoryStats implements IMeasure<Item, Map<String, Long>> {
-    public Map<String, Long> identity() {
-        return Collections.emptyMap();
-    }
-
-    public Map<String, Long> extract(Item item) {
-        return Map.of(item.category(), 1L);
-    }
-
-    public Map<String, Long> merge(Map<String, Long> a, Map<String, Long> b) {
-        Map<String, Long> result = new HashMap<>(a);
-        b.forEach((k, v) -> result.merge(k, v, Long::sum));
-        return result;
-    }
-
-    public Map<String, Long> remove(Map<String, Long> current, Item item,
-                                     Supplier<Map<String, Long>> recompute) {
-        // For invertible stats, compute directly
-        Map<String, Long> result = new HashMap<>(current);
-        result.computeIfPresent(item.category(), (k, v) -> v > 1 ? v - 1 : null);
-        return result;
-    }
-}
-```
-
-### Handling Non-Invertible Statistics
-
-Some statistics like `min` and `max` can't be updated incrementally when removing elements - if you remove the minimum, you need to scan to find the new one. The `remove` method receives a `recompute` supplier for this:
-
-```java
-public S remove(S current, Key key, Supplier<S> recompute) {
-    if (affectsResult(current, key)) {
-        // Can't compute incrementally, recompute from children
-        return recompute.get();
-    }
-    // Safe to compute incrementally
-    return subtractKey(current, key);
-}
-```
-
-The built-in `NumericStatsOps` handles this automatically for min/max.
-
-### ClojureScript Statistics
-
-For ClojureScript, implement the `IMeasure` protocol from `org.replikativ.persistent-sorted-set.impl.measure`:
-
-```cljs
-(require '[org.replikativ.persistent-sorted-set :as set])
-(require '[org.replikativ.persistent-sorted-set.impl.stats :as stats])
-(require '[org.replikativ.persistent-sorted-set.impl.numeric-stats :as numeric-stats])
-
-;; Use built-in numeric stats
-(def s (into (set/sorted-set* {:measure numeric-stats/numeric-stats-ops})
-             [1 2 3 4 5]))
-
-;; Or implement custom measure via the IMeasure protocol
-(defrecord MyStats [count sum])
-
-(def my-stats-ops
-  (reify measure/IMeasure
-    (identity-measure [_]
-      (->MyStats 0 0))
-
-    (extract [_ key]
-      (->MyStats 1 key))
-
-    (merge-measure [_ s1 s2]
-      (->MyStats (+ (:count s1) (:count s2))
-                 (+ (:sum s1) (:sum s2))))
-
-    (remove-measure [_ current key recompute-fn]
-      (->MyStats (dec (:count current))
-                 (- (:sum current) key)))))
-
-(def s (into (set/sorted-set* {:measure my-stats-ops}) [1 2 3 4 5]))
-```
+It is determinism-compatible across Clojure and ClojureScript (a tree built on the JVM and one
+built in the browser for the same key set are node-for-node identical), serializes its policy
+self-describingly, and is intentionally incompatible with diff buffering (forced off) and leaf
+processors (rejected). See [doc/merkle-search-tree.md](doc/merkle-search-tree.md) for the level
+function, the geometric size distribution, canonicality of `conj`/`disj`, and the rationale.
 
 ## Performance
 
-To reproduce:
+To reproduce: install `[com.datomic/datomic-free "0.9.5703"]` locally and run `lein bench`.
 
-1. Install `[com.datomic/datomic-free "0.9.5703"]` locally.
-2. Run `lein bench`.
+`PersistentTreeSet` is Clojure's red-black-tree sorted-set. `BTSet` is Datomic's B-tree sorted
+set (no transients, no disjoins). `PersistentSortedSet` is this implementation. Numbers on a
+3.2 GHz i7-8700B:
 
-`PersistentTreeSet` is Clojure’s Red-black tree based sorted-set.
-`BTSet` is Datomic’s B-tree based sorted set (no transients, no disjoins).
-`PersistentSortedSet` is this implementation.
-
-Numbers I get on my 3.2 GHz i7-8700B:
-
-### Conj 100k randomly sorted Integers
+**Conj 100k randomly sorted Integers**
 
 ```
-PersistentTreeSet                 143..165ms  
-BTSet                             125..141ms  
-PersistentSortedSet               105..121ms  
-PersistentSortedSet (transient)   50..54ms    
+PersistentTreeSet                 143..165ms
+BTSet                             125..141ms
+PersistentSortedSet               105..121ms
+PersistentSortedSet (transient)   50..54ms
 ```
 
-### Call contains? 100k times with random Integer on a 100k Integers set
+**`contains?` 100k times with random Integer on a 100k set**
 
 ```
-PersistentTreeSet     51..54ms    
-BTSet                 45..47ms    
-PersistentSortedSet   46..47ms    
+PersistentTreeSet     51..54ms
+BTSet                 45..47ms
+PersistentSortedSet   46..47ms
 ```
 
-### Iterate with java.util.Iterator over a set of 1M Integers
+**Iterate with java.util.Iterator over 1M Integers**
 
 ```
-PersistentTreeSet     70..77ms    
-PersistentSortedSet   10..11ms    
+PersistentTreeSet     70..77ms
+PersistentSortedSet   10..11ms
 ```
 
-### Iterate with ISeq.first/ISeq.next over a set of 1M Integers
+**Iterate with ISeq.first/next over 1M Integers**
 
 ```
-PersistentTreeSet     116..124ms  
-BTSet                 92..105ms   
-PersistentSortedSet   56..68ms    
+PersistentTreeSet     116..124ms
+BTSet                 92..105ms
+PersistentSortedSet   56..68ms
 ```
 
-### Iterate over a part of a set from 1 to 999999 in a set of 1M Integers
+**Iterate over a part of a 1M-Integer set (1 .. 999999)**
 
-For `PersistentTreeSet` we use ISeq produced by `(take-while #(<= % 999999) (.seqFrom set 1 true))`.
-
-For `PersistentSortedSet` we use `(.slice set 1 999999)`.
-
-```
-PersistentTreeSet     238..256ms  
-PersistentSortedSet   70..91ms    
-```
-
-### Disj 100k elements in randomized order from a set of 100k Integers
+For `PersistentTreeSet`: `(take-while #(<= % 999999) (.seqFrom set 1 true))`. For
+`PersistentSortedSet`: `(.slice set 1 999999)`.
 
 ```
-PersistentTreeSet                 151..155ms  
-PersistentSortedSet               91..98ms    
-PersistentSortedSet (transient)   47..50ms    
+PersistentTreeSet     238..256ms
+PersistentSortedSet   70..91ms
+```
+
+**Disj 100k elements in randomized order from a 100k set**
+
+```
+PersistentTreeSet                 151..155ms
+PersistentSortedSet               91..98ms
+PersistentSortedSet (transient)   47..50ms
 ```
 
 ## Projects using PersistentSortedSet
 
-- [DataScript](https://github.com/tonsky/datascript), persistent in-memory database
-- [Datahike](https://github.com/replikativ/datahike), durable Datalog database with persistent storage
+- [DataScript](https://github.com/tonsky/datascript) — persistent in-memory database
+- [Datahike](https://github.com/replikativ/datahike) — durable Datalog database with persistent
+  storage
+- [yggdrasil](https://github.com/replikativ/yggdrasil) — CRDTs over content-addressed storage
+
+## Development
+
+### Building
+
+```bash
+export JAVA8_HOME="/path/to/jdk1.8.0_202"   # Java 8 required for the bootclasspath
+lein jar
+```
+
+### Testing
+
+```bash
+lein test                       # Clojure
+yarn shadow-cljs release test   # ClojureScript
+```
+
+### CI/CD
+
+This project uses CircleCI: both Clojure and ClojureScript tests run on every commit, formatting
+is checked with cljfmt, and successful `main` builds are deployed to
+[Clojars](https://clojars.org/io.replikativ/persistent-sorted-set) and released to
+[GitHub](https://github.com/replikativ/persistent-sorted-set/releases). Versions follow
+`0.4.{commit-count}`.
+
+### Code formatting
+
+```bash
+clj -M:format   # check
+clj -M:ffix     # auto-fix
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -372,61 +372,29 @@ function, the geometric size distribution, canonicality of `conj`/`disj`, and th
 
 ## Performance
 
-To reproduce: install `[com.datomic/datomic-free "0.9.5703"]` locally and run `lein bench`.
+`PersistentSortedSet` vs `clojure.core/sorted-set` (a red-black `PersistentTreeSet`) on the
+same operations. Indicative criterium `quick-bench` means, Clojure 1.12 / JDK 25, Intel Core
+Ultra 7 258V — treat the **speedup ratios** as the robust takeaway (absolute ms vary with
+machine load):
 
-`PersistentTreeSet` is Clojure's red-black-tree sorted-set. `BTSet` is Datomic's B-tree sorted
-set (no transients, no disjoins). `PersistentSortedSet` is this implementation. Numbers on a
-3.2 GHz i7-8700B:
+| operation | `sorted-set` | `PersistentSortedSet` | speedup |
+|---|--:|--:|--:|
+| conj 100k random ints | 54.8 ms | 32.9 ms | ~1.7× |
+| conj 100k (transient) | — | 29.1 ms | ~1.9× |
+| `contains?` 100k on a 100k set | 14.5 ms | 11.4 ms | ~1.3× |
+| iterate (ISeq first/next) 1M | 28.1 ms | 13.0 ms | ~2.2× |
+| iterate sub-range 1..999999 of 1M | 80.1 ms | 8.1 ms | ~9.9× |
+| disj 100k random ints | 60.0 ms | 57.7 ms | ~1.0× |
+| disj 100k (transient) | — | 17.2 ms | ~3.5× |
 
-**Conj 100k randomly sorted Integers**
+The largest wins are in **range iteration** (`slice` descends to the sub-range instead of
+walking from the start) and **transient batch** build/teardown. The sub-range row uses
+`(subseq s >= 1)` + `take-while` for `sorted-set` vs `(set/slice s 1 999999)` for
+PersistentSortedSet.
 
-```
-PersistentTreeSet                 143..165ms
-BTSet                             125..141ms
-PersistentSortedSet               105..121ms
-PersistentSortedSet (transient)   50..54ms
-```
-
-**`contains?` 100k times with random Integer on a 100k set**
-
-```
-PersistentTreeSet     51..54ms
-BTSet                 45..47ms
-PersistentSortedSet   46..47ms
-```
-
-**Iterate with java.util.Iterator over 1M Integers**
-
-```
-PersistentTreeSet     70..77ms
-PersistentSortedSet   10..11ms
-```
-
-**Iterate with ISeq.first/next over 1M Integers**
-
-```
-PersistentTreeSet     116..124ms
-BTSet                 92..105ms
-PersistentSortedSet   56..68ms
-```
-
-**Iterate over a part of a 1M-Integer set (1 .. 999999)**
-
-For `PersistentTreeSet`: `(take-while #(<= % 999999) (.seqFrom set 1 true))`. For
-`PersistentSortedSet`: `(.slice set 1 999999)`.
-
-```
-PersistentTreeSet     238..256ms
-PersistentSortedSet   70..91ms
-```
-
-**Disj 100k elements in randomized order from a 100k set**
-
-```
-PersistentTreeSet                 151..155ms
-PersistentSortedSet               91..98ms
-PersistentSortedSet (transient)   47..50ms
-```
+Earlier published figures additionally compared Datomic's `BTSet` (B-tree, no transients/
+disjoins); install `[com.datomic/datomic-free "0.9.5703"]` to reproduce that three-way
+comparison.
 
 ## Projects using PersistentSortedSet
 

--- a/dev/hash_bench.clj
+++ b/dev/hash_bench.clj
@@ -1,0 +1,69 @@
+(ns hash-bench
+  "Hashing-only microbenchmark (no PSS). The MST per-op cost is dominated by re-hashing every
+   key in a leaf on each insert (the generic overflows/splitLengths scan). This measures whether
+   (a) caching each key's hash/level once, and (b) hasch's xor aggregate for the node address,
+   remove that cost — vs the unit cost of a single hash. Run:
+
+     clj -Sdeps '{:deps {org.replikativ/hasch {:mvn/version \"0.4.98\"}}}' -M:dev -e \"(require 'hash-bench)(hash-bench/report)\""
+  (:require [hasch.fast :as hf]
+            [hasch.core :as hc]
+            [hasch.benc :as benc])
+  (:import [java.util HashMap]))
+
+(defn- bench* [iters f]
+  (dotimes [_ (quot iters 10)] (f))                 ; warm
+  (let [t0 (System/nanoTime)]
+    (dotimes [_ iters] (f))
+    (/ (double (- (System/nanoTime) t0)) iters 1000.0))) ; µs/call
+
+(defn key-level-fast ^long [k ^long lzpl]
+  (let [^bytes h (hf/edn-hash k)
+        x (bit-or (bit-shift-left (bit-and (aget h 0) 0xff) 24)
+                  (bit-shift-left (bit-and (aget h 1) 0xff) 16)
+                  (bit-shift-left (bit-and (aget h 2) 0xff) 8)
+                  (bit-and (aget h 3) 0xff))]
+    (quot (Integer/numberOfLeadingZeros (unchecked-int x)) lzpl)))
+
+(def families
+  {:int    (fn [i] i)
+   :record (fn [i] [(format "sys-%07d" i) "main" i :meta])
+   :ormap  (fn [i] [(str (hc/uuid i)) (str (hc/uuid (+ i 7777))) (keyword (str "k" i)) i])})
+
+(defn report []
+  (println "\n=== hashing-only microbenchmark (µs/op) ===\n")
+  (let [N 50000]
+    (doseq [[fam gen] families]
+      (println "---- family" fam "----")
+      (let [els (mapv gen (range 1000))
+            pick (fn [] (nth els (rand-int 1000)))]
+        ;; 1. unit hash cost
+        (println " hasch.fast/edn-hash :" (format "%.3f" (bench* N #(hf/edn-hash (pick)))))
+        (println " hasch.core/edn-hash :" (format "%.3f" (bench* (quot N 5) #(hc/edn-hash (pick)))))
+        (println " key-level (fast+lz) :" (format "%.3f" (bench* N #(key-level-fast (pick) 6))))
+
+        ;; 2. cache: hash each key once, then lookups
+        (let [^HashMap cache (HashMap.)
+              _ (doseq [e els] (.put cache e (key-level-fast e 6)))]
+          (println " cached level lookup :" (format "%.4f" (bench* N #(.get cache (pick))))))
+
+        ;; 3. leaf scan: naive (B hashes) vs cached (B lookups), B=64
+        (let [leaf (vec (take 64 els))
+              ^HashMap cache (HashMap.)
+              _ (doseq [e leaf] (.put cache e (key-level-fast e 6)))]
+          (println " leaf scan B=64 naive:" (format "%.2f" (bench* (quot N 50) #(reduce (fn [a e] (+ a (key-level-fast e 6))) 0 leaf))))
+          (println " leaf scan B=64 cached:" (format "%.3f" (bench* (quot N 10) #(reduce (fn [a e] (+ a ^long (.get cache e))) 0 leaf)))))
+
+        ;; 4. node address via xor-aggregate: from-scratch vs incremental (one key XORed in)
+        (let [leaf (vec (take 64 els))
+              khashes (mapv #(hf/edn-hash %) leaf)]   ; precomputed per-key hashes
+          (println " node xor scratch B64:" (format "%.2f" (bench* (quot N 50) #(benc/xor-hashes (mapv hf/edn-hash leaf)))))
+          (println " node xor from-cached:" (format "%.3f" (bench* (quot N 10) #(benc/xor-hashes khashes))))
+          (let [base (benc/xor-hashes khashes)
+                newh (hf/edn-hash (gen 999999))]
+            (println " node xor incremental:" (format "%.4f"
+                      (bench* N #(let [^bytes acc (aclone ^bytes base)]
+                                   (dotimes [i (min 32 (alength acc))]
+                                     (aset acc i (byte (bit-xor (aget acc i) (aget ^bytes newh i)))))
+                                   acc))))))
+        (println))))
+  (println "=== done ==="))

--- a/dev/pss_mst_bench.clj
+++ b/dev/pss_mst_bench.clj
@@ -1,0 +1,135 @@
+(ns pss-mst-bench
+  "Stage A microbenchmark for the MST (content-defined) boundary mode. Quantifies the gains
+   that motivate prolly mode for yggdrasil/spindel state sync, and the costs. Run:
+
+     clj -Sdeps '{:deps {org.replikativ/hasch {:mvn/version \"0.4.98\"}}}' -M:dev -e \"(require 'pss-mst-bench)(pss-mst-bench/report)\"
+
+   Node addresses mirror datahike/yggdrasil exactly: a node's address is hasch/uuid over its
+   {:level :keys :addresses} map, computed Merkle-style bottom-up. So 'ship-set' = the node
+   addresses one replica holds that the other lacks — the real konserve-sync transfer unit."
+  (:require [org.replikativ.persistent-sorted-set :as pss]
+            [org.replikativ.persistent-sorted-set.boundary :as bnd]
+            [hasch.core :as h]
+            [clojure.set :as set])
+  (:import [org.replikativ.persistent_sorted_set Leaf Branch ANode PersistentSortedSet]))
+
+;; ---------- node addressing (Merkle, bottom-up; == yggdrasil hasch/uuid(node->map)) ----------
+
+(defn- keys-of [node]
+  (let [k (.-_keys ^ANode node) n (.-_len ^ANode node)]
+    (mapv #(aget ^objects k %) (range n))))
+
+(defn- collect
+  "Bottom-up walk. Returns {:addr <merkle hash> :addrs #{all node hashes} :leaves [leaf sizes]}."
+  [node]
+  (if (instance? Leaf node)
+    (let [a (h/uuid {:level 0 :keys (keys-of node)})]
+      {:addr a :addrs #{a} :leaves [(.-_len ^Leaf node)]})
+    (let [n (.-_len ^Branch node)
+          children (mapv #(aget ^objects (.-_children ^Branch node) %) (range n))
+          sub (mapv collect children)
+          a (h/uuid {:level (.-_level ^Branch node)
+                     :keys (keys-of node)
+                     :addresses (mapv :addr sub)})]
+      {:addr a
+       :addrs (conj (reduce set/union #{} (map :addrs sub)) a)
+       :leaves (vec (mapcat :leaves sub))})))
+
+(defn tree-info [^PersistentSortedSet s]
+  (let [r (collect (.root s))]
+    {:addrs (:addrs r) :nodes (count (:addrs r)) :leaves (:leaves r) :root (:addr r)}))
+
+;; ---------- construction ----------
+
+(def BF 64)                              ; matches yggdrasil durable.cljc:43
+(defn- count-opts [] {:branching-factor BF})
+(defn- mst-opts [lzpl] {:branching-factor BF :boundary (bnd/mst-boundary lzpl)})
+
+(defn make-set [elements opts] (reduce conj (pss/sorted-set* opts) elements))
+
+(defn elements [family n]
+  (case family
+    :int    (vec (range n))
+    ;; ~RegistryEntry-sized: [sys branch tx tag]
+    :record (mapv (fn [i] [(format "sys-%07d" i) "main" i :meta]) (range n))
+    ;; ~OR-Map [hk uid k v] with two uuid-strings
+    :ormap  (mapv (fn [i] [(str (h/uuid i)) (str (h/uuid (+ i 7777))) (keyword (str "k" i)) i])
+                  (range n))))
+
+;; ---------- metrics ----------
+
+(defn dist-stats [leaves]
+  (let [n (count leaves) s (reduce + leaves) mean (double (/ s n))
+        var (double (/ (reduce + (map #(let [d (- % mean)] (* d d)) leaves)) n))
+        sd (Math/sqrt var)]
+    {:leaves n :mean (Math/round mean) :cv (/ sd mean)
+     :min (apply min leaves) :max (apply max leaves)
+     :singletons (count (filter #(= 1 %) leaves))}))
+
+(defn dedup-scenario
+  "Same element SET built in K different insertion orders. How many DISTINCT node addresses
+   across all K trees, and the ship-set between two replicas that converged on the same set?"
+  [base K opts]
+  (let [infos (mapv #(tree-info (make-set % opts)) (repeatedly K #(shuffle base)))
+        all   (reduce set/union #{} (map :addrs infos))
+        per   (double (/ (reduce + (map :nodes infos)) K))]
+    {:per-tree (Math/round per)
+     :distinct (count all)
+     :sharing  (format "%.2fx" (/ (* K per) (count all)))   ; 1x = no sharing, Kx = full sharing
+     :roots-identical (apply = (map :root infos))
+     :ship-between-converged-replicas (count (set/difference (:addrs (first infos))
+                                                             (:addrs (second infos))))}))
+
+(defn incremental-scenario
+  "Two peers A,B independently hold the SAME base set (different histories). A then applies a
+   small delta. Sync A->B: how many nodes must ship? Ideal = only the nodes the delta changed."
+  [base delta opts]
+  (let [A  (make-set (shuffle base) opts)
+        B  (make-set (shuffle base) opts)
+        A2 (reduce conj A delta)
+        ia (tree-info A) ia2 (tree-info A2) ib (tree-info B)
+        ideal (count (set/difference (:addrs ia2) (:addrs ia)))      ; nodes the delta touched
+        ship  (count (set/difference (:addrs ia2) (:addrs ib)))]     ; nodes B must actually fetch
+    {:delta (count delta) :ideal-new-nodes ideal :must-ship ship
+     :overhead (format "%.0fx" (/ (double ship) (max 1 ideal)))}))
+
+(defn op-cost-us [family n opts]
+  (let [els (elements family n)]
+    (make-set (take 200 els) opts)            ; warm
+    (let [t0 (System/nanoTime) _ (make-set els opts) dt (- (System/nanoTime) t0)]
+      (/ (double dt) n 1000.0))))             ; µs per conj
+
+;; ---------- report ----------
+
+(defn report []
+  (println "\n=== Stage A: MST boundary microbenchmark (bf/fanout =" BF ", lzpl 6 = B 64) ===\n")
+  (doseq [family [:int :record :ormap]]
+    (println "########## element family:" family "##########")
+    (let [n 20000
+          base (elements family n)
+          ;; delta = 5 fresh elements disjoint from base (indices >= n)
+          delta (mapv (fn [i] (case family
+                                :int (+ n i)
+                                :record [(format "sys-%07d" (+ n i)) "main" (+ n i) :meta]
+                                :ormap [(str (h/uuid (+ n i))) (str (h/uuid (+ n i 7777))) (keyword (str "k" (+ n i))) (+ n i)]))
+                      (range 5))]
+      (do
+        (println "\n-- node-size distribution (n=" n ") --")
+        (println "  count(bf64):" (dist-stats (:leaves (tree-info (make-set base (count-opts))))))
+        (doseq [lzpl [4 6 8]]
+          (println "  mst(lzpl" lzpl "B" (int (Math/pow 2 lzpl)) "):"
+                   (dist-stats (:leaves (tree-info (make-set base (mst-opts lzpl)))))))
+
+        (println "\n-- cross-replica dedup (same set, 4 orders) --")
+        (println "  count(bf64):" (dedup-scenario base 4 (count-opts)))
+        (println "  mst(lzpl6) :" (dedup-scenario base 4 (mst-opts 6)))
+
+        (println "\n-- incremental sync between divergent-history replicas (+5 elems) --")
+        (println "  count(bf64):" (incremental-scenario base delta (count-opts)))
+        (println "  mst(lzpl6) :" (incremental-scenario base delta (mst-opts 6)))
+
+        (println "\n-- per-conj cost (µs/op) --")
+        (println "  count(bf64):" (format "%.2f" (op-cost-us family n (count-opts))))
+        (println "  mst(lzpl6) :" (format "%.2f" (op-cost-us family n (mst-opts 6))))
+        (println))))
+  (println "=== done ==="))

--- a/doc/README.md
+++ b/doc/README.md
@@ -12,7 +12,7 @@ Deep-dives behind the features summarized in the [project README](../README.md).
   contract. Opt-in, off by default.
 
 ## Content-addressing & sync
-- **[Merkle Search Tree (content-defined boundaries)](merkle-search-tree.md)** — *prolly* mode:
+- **[Merkle Search Tree (content-defined boundaries)](merkle-search-tree.md)** — _**experimental**_, *prolly* mode:
   split decisions derived from key hashes so that **equal sets are byte-identical trees**,
   independent of operation history. For CRDT state sync, cross-replica dedup, and O(1)
   idempotence. Opt-in, off by default.

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,32 @@
+# PersistentSortedSet documentation
+
+Deep-dives behind the features summarized in the [project README](../README.md).
+
+## Storage & durability
+- **[Serialization](serialization.md)** — the optional canonical Fressian read/write handlers
+  for nodes and roots (`pss/leaf`, `pss/branch`, `pss/set`); self-describing blobs; resolver
+  registries for shared/wire serializers.
+- **[Diff buffering](diff-buffering.md)** — write-amplification reduction on content-addressed
+  storage: bring a content-only commit down to ~1 object by buffering each unchanged-structure
+  child's diff at the serialization boundary. Model, invariants, on-disk format, storage
+  contract. Opt-in, off by default.
+
+## Content-addressing & sync
+- **[Merkle Search Tree (content-defined boundaries)](merkle-search-tree.md)** — *prolly* mode:
+  split decisions derived from key hashes so that **equal sets are byte-identical trees**,
+  independent of operation history. For CRDT state sync, cross-replica dedup, and O(1)
+  idempotence. Opt-in, off by default.
+
+## Queries & statistics
+- **[Statistical queries](statistical-queries.md)** — subtree counts and the monoidal
+  `:measure` mechanism behind `count-slice`, `get-nth` (rank/percentile access), `measure`, and
+  `measure-slice`.
+
+## Internals
+- **[B-tree operations](btree-operations.md)** — the split/merge/borrow mechanics, transients,
+  and the node-level invariants shared by all boundary modes.
+
+---
+
+For the public API and worked examples, start with the [README](../README.md). The version
+history is in [CHANGES.md](../CHANGES.md).

--- a/doc/merkle-search-tree.md
+++ b/doc/merkle-search-tree.md
@@ -1,0 +1,177 @@
+# Content-defined boundaries (Merkle Search Tree / prolly mode)
+
+By default PersistentSortedSet is an ordinary B+-tree: a node splits when it reaches the
+branching factor, so the **shape of the tree depends on the order** keys were inserted and
+removed. Two sets with identical contents but different histories are equal as sets, yet they
+are laid out differently in memory and on disk.
+
+**Content-defined boundary mode** (a *Merkle Search Tree*, the family informally called
+*prolly trees*) removes that history dependence. Where a node splits is decided by a
+deterministic function of the **keys themselves**, not by insertion order or node fill. The
+result is a tree that is a pure function of its element set:
+
+> **Same elements ⇒ byte-identical tree**, regardless of the order of `conj`/`disj`, of bulk
+> vs incremental construction, or of which JVM/JS peer built it.
+
+This is opt-in, per set, and the default count B-tree is completely unaffected (it needs no
+hashing). It exists primarily for **CRDT state synchronization and content-addressed dedup**:
+when a node's address is the hash of its canonical content, two replicas that have converged
+to the same logical state share the same nodes, so syncing them ships *zero* objects and
+idempotence is an O(1) root-hash comparison instead of an O(n) element walk.
+
+## Quick start
+
+```clojure
+(require '[org.replikativ.persistent-sorted-set :as set]
+         '[org.replikativ.persistent-sorted-set.boundary :as b])
+
+;; lzpl = "leading-zeros per level" — sets the target fanout (avg node ≈ 2^lzpl keys).
+;; 4 ⇒ ~16, 5 ⇒ ~32, 6 ⇒ ~64. Larger ⇒ shallower, more uniform nodes.
+(def s (into (set/sorted-set* {:boundary (b/mst-boundary 5)})
+             (shuffle (range 10000))))
+
+;; History-independence: any build order yields the identical structure.
+(= (into (set/sorted-set* {:boundary (b/mst-boundary 5)}) (range 10000))
+   (into (set/sorted-set* {:boundary (b/mst-boundary 5)}) (shuffle (range 10000))))
+;=> true, and the two trees are node-for-node identical
+```
+
+`mst-boundary` exists on both Clojure and ClojureScript and is determinism-compatible across
+them: a tree built on the JVM and a tree built in the browser for the same key set are
+node-for-node identical, so they content-address to the same hashes.
+
+## How the boundary is decided
+
+Every key is assigned a **level** by hashing it:
+
+```
+key-level(K) = leadingZeros( top-32-bits( hash(K) ) ) / lzpl
+```
+
+- `hash` is [hasch](https://github.com/replikativ/hasch)'s `hasch.fast/edn-hash` — a binary
+  encoding that is **byte-identical on JVM and JS** (this is what makes the tree
+  cross-platform).
+- `leadingZeros` is `Integer/numberOfLeadingZeros` ≡ `js/Math.clz32` — also identical across
+  platforms.
+- Dividing by `lzpl` (leading-zeros-per-level) buckets keys into levels with a **geometric**
+  distribution: `P(level ≥ n) = 2^(−n·lzpl)`. With `lzpl = 5`, ~1/32 of keys reach level ≥ 1,
+  ~1/1024 reach level ≥ 2, and so on.
+
+A key's level is a pure function of the key. A key that reaches level `L` becomes a
+**boundary** (a separator) at every level below `L`. The split rule is then trivial and the
+same for leaves and branches:
+
+> A node ends immediately after each interior key whose level reaches this node's level + 1.
+> The node's last key is its terminator (the parent's separator / the global maximum) and is
+> never treated as an interior cut.
+
+Because boundaries are intrinsic to the keys, inserting or deleting one key can only change
+the node it lands in (and possibly promote a new spine) — it can never shift where *other*
+keys split. That locality is exactly what makes the structure history-independent.
+
+### Why levels, not a rolling hash
+
+This is *textbook* MST: the level is a function of the **single key's hash**. Some prolly-tree
+designs (e.g. Dolt) instead run a rolling/content-defined chunker over the serialized stream,
+which couples chunk boundaries to byte size and gives more uniform node sizes — at the cost of
+unbounded "boundary ripple" that needs a streaming chunker to bound. The per-key scheme trades
+size uniformity for **strict locality and O(1) split decisions**, which is the better fit for
+an in-memory persistent tree that also serves point and range queries.
+
+### The geometric size distribution
+
+A consequence of per-key levels is that node sizes follow a geometric distribution (mean
+`2^lzpl`, coefficient of variation ≈ 0.9) rather than the tight `[B/2, B]` band of a classic
+B-tree. Occasional single-key nodes and the odd deep spine are expected — the tree is, by
+design, slightly out of balance "by bad luck" (the same level-distribution that drives skip
+lists and HNSW). At realistic fanouts this is a non-issue: at `lzpl = 6` (B≈64) only ~1% of
+nodes are singletons, and the tree stays height-balanced (all leaves at the same depth).
+
+## What it costs and what it buys
+
+| | default (count B-tree) | content-defined (MST) |
+|---|---|---|
+| split decision | node fill ≥ branching factor | `key-level` (one hash per inserted key) |
+| structure | depends on insert/remove order | pure function of the element set |
+| node sizes | tight `[B/2, B]` | geometric (mean `2^lzpl`) |
+| per-op cost | no hashing | ~1 hash/op (hasch.fast) |
+| cross-replica dedup | none (history-dependent) | full (converged subtrees share addresses) |
+| serialization | count B-tree handlers | self-describing `{:type :mst :lzpl …}` |
+
+Use MST when you content-address nodes and care that **equal sets are equal trees**: CRDT
+merge + idempotence detection (the [yggdrasil](https://github.com/replikativ/yggdrasil) use
+case), efficient replica-to-replica sync, deduplicating snapshot storage. Stick with the
+default for plain in-memory or single-writer durable use — it is faster (no hashing) and the
+node sizes are tighter.
+
+## conj / disj are canonical
+
+`conj` and `disj` behave exactly as for any sorted set; the only difference is the split/merge
+decision. After **any** sequence of operations the tree equals a fresh build of the surviving
+elements:
+
+```clojure
+(let [a (-> (into (set/sorted-set* {:boundary (b/mst-boundary 4)}) (range 100))
+            (conj 250) (disj 7) (conj 7) (disj 99))
+      b (into (set/sorted-set* {:boundary (b/mst-boundary 4)}) (-> (range 100) set (conj 250) (disj 99)))]
+  (= a b))            ;=> true — and structurally identical, not merely set-equal
+```
+
+Internally:
+- **Insert** uses an O(1) decision: only the inserted key (or, on append, the displaced old
+  maximum) can introduce a new boundary, since an MST node has no interior boundaries except
+  its terminator.
+- **Remove** rebuilds only the affected node and re-derives boundaries locally; merges across
+  a live boundary are forbidden (a key that is still a boundary keeps its node separate), which
+  is what preserves canonicality. Deleting the maximum can collapse a degenerate spine.
+
+This is exercised on both platforms by a model-based generative test that drives a random
+**interleaved** `conj`/`disj` sequence against `clojure.core/sorted-set` and asserts (a) the
+elements match the oracle, (b) the tree satisfies the MST structural invariants, and (c) it is
+node-for-node identical to a fresh build of the survivors. See
+`test-clojure/.../test/mst.cljc`.
+
+## Durability and serialization
+
+MST sets store and restore through the same `IStorage` path as any other PSS (see
+[Durability](../README.md#durability)). Two points specific to content-defined mode:
+
+- **The boundary policy is self-describing.** Each node serializes a small descriptor
+  (`{:type :mst :lzpl N}`) into its blob via the
+  [canonical Fressian handlers](serialization.md). On `restore`, PSS reconstructs the MST
+  boundary internally from that descriptor — **no consumer-supplied configuration is needed**.
+  The split strategies are known to PSS, so a durable store round-trips its own policy.
+- **A node's content address excludes the boundary descriptor.** The Merkle address is
+  `hash({:level … :keys … :addresses …})` — the descriptor is *configuration*, not content, so
+  two stores that agree on contents content-address identically even if recorded separately.
+
+Removal on a durable (lazily-loaded) MST set is storage-aware on both JVM and ClojureScript:
+it preserves the addresses of untouched children and calls `markFreed` for the nodes it
+replaces, so a content-addressed backend can garbage-collect the obsolete objects.
+
+## Incompatibilities
+
+A content-defined boundary is deliberately **incompatible with two features**, and PSS rejects
+or neutralizes the combination rather than letting it be constructed silently:
+
+- **Diff buffering is forced off.** [Diff buffering](diff-buffering.md) addresses a buffered
+  spine node by `hash(anchor + diff)` — a function of *flush history*, not canonical content —
+  which is precisely the history-dependence MST exists to remove, and it would break
+  cross-peer dedup. The two make opposite promises (diff-buf: *content changed without changing
+  address*; MST: *address ≡ content hash*), so enabling MST sets `:diff-buf-size` to `0`. See
+  diff-buffering.md for the full argument.
+- **Leaf processors are rejected.** The O(1) insert decision assumes a single key was inserted
+  per op; a leaf processor that rewrites multiple entries per op would violate that invariant,
+  so combining the two throws.
+
+## API
+
+| | |
+|---|---|
+| `(b/mst-boundary lzpl)` | build a boundary policy; `lzpl` sets fanout (avg node ≈ `2^lzpl`) |
+| `(set/sorted-set* {:boundary …})` | create a set in content-defined mode |
+| `(set/from-sorted-array cmp arr n {:boundary …})` | bulk-build in content-defined mode |
+| `(b/key-level key lzpl)` | the level a key rises to (the determinism primitive) |
+
+The default — omitting `:boundary` — is the count B-tree and is byte-identical to every prior
+release.

--- a/doc/merkle-search-tree.md
+++ b/doc/merkle-search-tree.md
@@ -1,5 +1,13 @@
 # Content-defined boundaries (Merkle Search Tree / prolly mode)
 
+> **⚠️ Experimental.** This mode is new and opt-in. The public API (`mst-boundary`, the
+> `:boundary` setting) and the serialized boundary descriptor (`{:type :mst :lzpl N}`) may still
+> change; it has not yet been hardened in production sync workloads, so don't depend on the
+> on-disk format for long-lived MST data yet. The cross-platform determinism and
+> `conj`/`disj`/`replace` canonicality are property-tested on both JVM and ClojureScript, but
+> treat the feature as unstable. The default count B-tree (no `:boundary`) is unaffected and
+> stable.
+
 By default PersistentSortedSet is an ordinary B+-tree: a node splits when it reaches the
 branching factor, so the **shape of the tree depends on the order** keys were inserted and
 removed. Two sets with identical contents but different histories are equal as sets, yet they

--- a/src-clojure/org/replikativ/persistent_sorted_set.clj
+++ b/src-clojure/org/replikativ/persistent_sorted_set.clj
@@ -160,11 +160,12 @@
            (:leaf-processor m)
            ;; diff-buf: fall back to the shared Settings default (Settings/defaultDiffBufSize,
            ;; 0/off unless the pss.diffBufSize sysprop is set) when the caller doesn't specify.
-           ;; 0 = baseline (I0). See doc/diff-buffering.md. A content-defined boundary forces
-           ;; diff-buf OFF: the two are incompatible (a buffered spine node is addressed by
-           ;; hash(anchor+diff), not its canonical content hash, which breaks cross-peer dedup —
-           ;; the very property MST exists for; see .internal/SPLIT_SEAM_DESIGN.md two-hash note).
-           (if boundary 0 (int (or (:diff-buf-size m) (Settings/defaultDiffBufSize)))))
+           ;; 0 = baseline (I0). See doc/diff-buffering.md. The MST incompatibility (a buffered
+           ;; spine node is addressed by hash(anchor+diff), not its canonical content hash, which
+           ;; breaks the cross-peer dedup MST exists for) is enforced in ONE place — `.withBoundary`
+           ;; below forces diff-buf OFF for a *content-defined* boundary (a non-content boundary is
+           ;; left untouched). See .internal/SPLIT_SEAM_DESIGN.md two-hash note.
+           (int (or (:diff-buf-size m) (Settings/defaultDiffBufSize))))
         ;; split-seam: opt into a content-defined boundary (e.g. MST) per store. nil ⇒ the
         ;; default count B-tree (byte-identical baseline). See .internal/SPLIT_SEAM_DESIGN.md.
         s (if boundary (.withBoundary s ^IBoundary boundary) s)]

--- a/src-clojure/org/replikativ/persistent_sorted_set.clj
+++ b/src-clojure/org/replikativ/persistent_sorted_set.clj
@@ -9,7 +9,7 @@
    [java.lang.ref SoftReference]
    [java.util Comparator Arrays]
    [java.util.function BiConsumer]
-   [org.replikativ.persistent_sorted_set ANode ArrayUtil Branch IMeasure IStorage ISubtreeCount Leaf PersistentSortedSet RefType Settings Seq]))
+   [org.replikativ.persistent_sorted_set ANode ArrayUtil Branch IBoundary IMeasure IStorage ISubtreeCount Leaf PersistentSortedSet RefType Settings Seq]))
 
 (set! *warn-on-reflection* true)
 
@@ -125,8 +125,31 @@
            (conj! (array-from-indexed coll type from (+ from (quot len 2))))
            (conj! (array-from-indexed coll type (+ from (quot len 2)) to)))))))
 
+(defn- elem-at [coll i]
+  (if (arrays/array? coll) (aget ^objects coll i) (nth coll i)))
+
+(defn- mst-split
+  "Bulk MST partition (matches incremental conj): cut coll[0..len) AFTER index i (i<len-1)
+   whose `key-of` value rises to `thresh` (= node-level+1). `key-of` maps a coll element to
+   the key to hash (identity for leaf keys, .maxKey for child nodes). Produces arrays via
+   array-from-indexed, exactly like the count `split`."
+  [^IBoundary boundary ^Settings settings coll len type key-of thresh]
+  (let [len (long len)
+        thresh (long thresh)
+        last-i (dec len)]
+    (loop [i 0, start 0, acc (transient [])]
+      (if (>= i len)
+        (persistent! (if (> len (long start))
+                       (conj! acc (array-from-indexed coll type start len))
+                       acc))
+        (if (and (< i last-i)
+                 (>= (.keyLevel boundary (key-of (elem-at coll i)) settings) thresh))
+          (recur (inc i) (inc i) (conj! acc (array-from-indexed coll type start (inc i))))
+          (recur (inc i) start acc))))))
+
 (defn- map->settings ^Settings [m]
-  (let [s (Settings.
+  (let [boundary (:boundary m)
+        s (Settings.
            (int (or (:branching-factor m) 0))
            (case (:ref-type m)
              :strong RefType/STRONG
@@ -137,8 +160,14 @@
            (:leaf-processor m)
            ;; diff-buf: fall back to the shared Settings default (Settings/defaultDiffBufSize,
            ;; 0/off unless the pss.diffBufSize sysprop is set) when the caller doesn't specify.
-           ;; 0 = baseline (I0). See doc/diff-buffering.md.
-           (int (or (:diff-buf-size m) (Settings/defaultDiffBufSize))))]
+           ;; 0 = baseline (I0). See doc/diff-buffering.md. A content-defined boundary forces
+           ;; diff-buf OFF: the two are incompatible (a buffered spine node is addressed by
+           ;; hash(anchor+diff), not its canonical content hash, which breaks cross-peer dedup —
+           ;; the very property MST exists for; see .internal/SPLIT_SEAM_DESIGN.md two-hash note).
+           (if boundary 0 (int (or (:diff-buf-size m) (Settings/defaultDiffBufSize)))))
+        ;; split-seam: opt into a content-defined boundary (e.g. MST) per store. nil ⇒ the
+        ;; default count B-tree (byte-identical baseline). See .internal/SPLIT_SEAM_DESIGN.md.
+        s (if boundary (.withBoundary s ^IBoundary boundary) s)]
     ;; diff-buf: the comparator is NOT stored on Settings — it lives on the PersistentSortedSet
     ;; (_cmp) and is propagated to Branch nodes (Branch._projCmp) for leaf projection.
     s))
@@ -193,12 +222,26 @@
                                    measure
                                    cmp
                                    settings)))]
-     (loop [level 1
-            nodes (mapv ->Leaf (split keys len Object avg-branching-factor max-branching-factor))]
-       (case (count nodes)
-         0 (PersistentSortedSet. {} cmp storage settings)
-         1 (PersistentSortedSet. {} cmp nil storage (first nodes) len settings 0)
-         (recur (inc level) (mapv #(->Branch level %) (split nodes (count nodes) Object avg-branching-factor max-branching-factor))))))))
+     (if (.contentDefined (.boundary settings))
+       ;; MST bulk: chunk by boundary level so a freshly-built tree matches an incrementally
+       ;; grown one for the same key set (history-independence). key-of = identity for leaf
+       ;; keys, .maxKey for child nodes; thresh = node-level+1.
+       (let [^IBoundary boundary (.boundary settings)]
+         (loop [level 1
+                nodes (mapv ->Leaf (mst-split boundary settings keys len Object identity 1))]
+           (case (count nodes)
+             0 (PersistentSortedSet. {} cmp storage settings)
+             1 (PersistentSortedSet. {} cmp nil storage (first nodes) len settings 0)
+             (recur (inc level)
+                    (mapv #(->Branch level %)
+                          (mst-split boundary settings nodes (count nodes) Object
+                                     (fn [^ANode n] (.maxKey n)) (inc level)))))))
+       (loop [level 1
+              nodes (mapv ->Leaf (split keys len Object avg-branching-factor max-branching-factor))]
+         (case (count nodes)
+           0 (PersistentSortedSet. {} cmp storage settings)
+           1 (PersistentSortedSet. {} cmp nil storage (first nodes) len settings 0)
+           (recur (inc level) (mapv #(->Branch level %) (split nodes (count nodes) Object avg-branching-factor max-branching-factor)))))))))
 
 (defn from-sequential
   "Create a set with custom comparator and a collection of keys. Useful when you don’t want to call [[clojure.core/apply]] on [[sorted-set-by]]."

--- a/src-clojure/org/replikativ/persistent_sorted_set/boundary.cljc
+++ b/src-clojure/org/replikativ/persistent_sorted_set/boundary.cljc
@@ -1,0 +1,110 @@
+(ns org.replikativ.persistent-sorted-set.boundary
+  "Optional content-defined boundary policies (prolly / Merkle Search Tree mode), for BOTH
+   platforms. Not required by core PSS — loaded only by consumers that opt into prolly mode
+   (the default count B-tree needs no hashing). Enable per store via
+   `{:boundary (mst-boundary <lzpl>)}`.
+
+   The determinism contract: a JVM writer and a cljs reader MUST compute the IDENTICAL tree
+   for the same key set, so the boundary structure is content-addressed identically. The
+   whole match reduces to `key-level` returning the same integer on both platforms, which it
+   does because (a) hasch.fast emits byte-identical hashes JVM↔cljs and (b) leading-zeros is
+   `Integer/numberOfLeadingZeros` ≡ `js/Math.clz32`. See .internal/SPLIT_SEAM_DESIGN.md.
+
+   `key-level` is the single shared (cljc) source of truth for that. The split RULE (cut after
+   each boundary key) is trivially identical and applied per-platform over native arrays: the
+   JVM impl reifies the Java IBoundary interface; the cljs impl is a PBoundary record."
+  (:require [hasch.fast :as hf]
+            #?(:cljs [org.replikativ.persistent-sorted-set.impl.boundary :as b]))
+  #?(:clj (:import [org.replikativ.persistent_sorted_set IBoundary])))
+
+;; ---- shared, determinism-critical -----------------------------------------------------
+
+(defn- clz32
+  "Leading zeros of x interpreted as a 32-bit unsigned value. JVM Integer/numberOfLeadingZeros
+   and JS Math.clz32 are defined identically, which is what makes key-level cross-platform."
+  ^long [x]
+  #?(:clj  (Integer/numberOfLeadingZeros (unchecked-int x))
+     :cljs (js/Math.clz32 x)))
+
+(defn- hash-u32
+  "Top 4 bytes of hasch.fast/edn-hash(key) assembled big-endian into a 32-bit value. hasch.fast
+   is byte-identical across JVM and cljs (binary encoding, mirrored encoders)."
+  [key]
+  (let [h (hf/edn-hash key)
+        b0 (bit-and #?(:clj (aget ^bytes h 0) :cljs (aget h 0)) 0xff)
+        b1 (bit-and #?(:clj (aget ^bytes h 1) :cljs (aget h 1)) 0xff)
+        b2 (bit-and #?(:clj (aget ^bytes h 2) :cljs (aget h 2)) 0xff)
+        b3 (bit-and #?(:clj (aget ^bytes h 3) :cljs (aget h 3)) 0xff)]
+    (bit-or (bit-shift-left b0 24)
+            (bit-shift-left b1 16)
+            (bit-shift-left b2 8)
+            b3)))
+
+(defn key-level
+  "The level a key rises to: 0 ⇒ leaf-only, ≥1 ⇒ separator at that level. Geometric:
+   P(level ≥ n) = 2^(-n·lzpl). Pure function of the key ⇒ history-independent. IDENTICAL on
+   JVM and cljs (the determinism guarantee)."
+  ^long [key ^long lzpl]
+  (quot (clz32 (hash-u32 key)) lzpl))
+
+;; ---- JVM: reify the Java IBoundary interface ------------------------------------------
+
+#?(:clj
+   (defn mst-boundary
+     "Build an MST IBoundary. `lzpl` (leading-zeros-per-level) sets target fanout: avg node
+      ≈ 2^lzpl keys. Boundary rule (leaves and branches alike): a chunk ends after a key K at
+      index i<len-1 whose key-level reaches level+1; the final key is the node terminator
+      (parent separator / global max), never an interior cut."
+     [lzpl]
+     (let [lzpl (long (max 1 lzpl))]
+       (reify IBoundary
+         (keyLevel [_ key _s] (key-level key lzpl))
+         (overflows [_ run len level _s]
+           (let [thresh (inc (long level))
+                 n (dec (long len))]
+             (loop [i 0]
+               (cond
+                 (>= i n) false
+                 (>= (key-level (aget ^objects run i) lzpl) thresh) true
+                 :else (recur (inc i))))))
+         (splitLengths [_ run len level _s]
+           (let [thresh (inc (long level))
+                 n (dec (long len))]
+             (loop [i 0, prev 0, acc (transient [])]
+               (if (>= i n)
+                 (int-array (persistent! (conj! acc (- (long len) (long prev)))))
+                 (if (>= (key-level (aget ^objects run i) lzpl) thresh)
+                   (recur (inc i) (inc i) (conj! acc (- (inc i) (long prev))))
+                   (recur (inc i) prev acc))))))
+         (contentDefined [_] true)))))
+
+;; ---- CLJS: implement the PBoundary protocol -------------------------------------------
+
+#?(:cljs
+   (defrecord MstBoundary [^number lzpl]
+     b/PBoundary
+     (-key-level [_ key] (key-level key lzpl))
+     (-overflows? [_ run len level]
+       (let [thresh (inc level)
+             n (dec len)]
+         (loop [i 0]
+           (cond
+             (>= i n) false
+             (>= (key-level (aget run i) lzpl) thresh) true
+             :else (recur (inc i))))))
+     (-split-lengths [_ run len level]
+       (let [thresh (inc level)
+             n (dec len)]
+         (loop [i 0, prev 0, acc (transient [])]
+           (if (>= i n)
+             (persistent! (conj! acc (- len prev)))
+             (if (>= (key-level (aget run i) lzpl) thresh)
+               (recur (inc i) (inc i) (conj! acc (- (inc i) prev)))
+               (recur (inc i) prev acc))))))
+     (-content-defined? [_] true)))
+
+#?(:cljs
+   (defn mst-boundary
+     "Build an MST PBoundary (cljs). `lzpl` sets target fanout (avg node ≈ 2^lzpl keys)."
+     [lzpl]
+     (->MstBoundary (max 1 lzpl))))

--- a/src-clojure/org/replikativ/persistent_sorted_set/boundary.cljc
+++ b/src-clojure/org/replikativ/persistent_sorted_set/boundary.cljc
@@ -59,23 +59,15 @@
      (let [lzpl (long (max 1 lzpl))]
        (reify IBoundary
          (keyLevel [_ key _s] (key-level key lzpl))
-         (overflows [_ run len level _s]
-           (let [thresh (inc (long level))
-                 n (dec (long len))]
-             (loop [i 0]
-               (cond
-                 (>= i n) false
-                 (>= (key-level (aget ^objects run i) lzpl) thresh) true
-                 :else (recur (inc i))))))
-         (splitLengths [_ run len level _s]
-           (let [thresh (inc (long level))
-                 n (dec (long len))]
-             (loop [i 0, prev 0, acc (transient [])]
-               (if (>= i n)
-                 (int-array (persistent! (conj! acc (- (long len) (long prev)))))
-                 (if (>= (key-level (aget ^objects run i) lzpl) thresh)
-                   (recur (inc i) (inc i) (conj! acc (- (inc i) (long prev))))
-                   (recur (inc i) prev acc))))))
+         ;; O(1): only the inserted key (or, when appended, the displaced old max) can be a
+         ;; new boundary, since an MST node has no interior boundaries except its terminator.
+         (splitOnInsert [_ run len ins level _s]
+           (let [thresh (inc (long level)) len (long len) ins (long ins)]
+             (if (< ins (dec len))
+               (when (>= (key-level (aget ^objects run ins) lzpl) thresh)
+                 (int-array [(inc ins) (- len (inc ins))]))
+               (when (and (>= len 2) (>= (key-level (aget ^objects run (- len 2)) lzpl) thresh))
+                 (int-array [(dec len) 1])))))
          (contentDefined [_] true)))))
 
 ;; ---- CLJS: implement the PBoundary protocol -------------------------------------------
@@ -84,23 +76,13 @@
    (defrecord MstBoundary [^number lzpl]
      b/PBoundary
      (-key-level [_ key] (key-level key lzpl))
-     (-overflows? [_ run len level]
-       (let [thresh (inc level)
-             n (dec len)]
-         (loop [i 0]
-           (cond
-             (>= i n) false
-             (>= (key-level (aget run i) lzpl) thresh) true
-             :else (recur (inc i))))))
-     (-split-lengths [_ run len level]
-       (let [thresh (inc level)
-             n (dec len)]
-         (loop [i 0, prev 0, acc (transient [])]
-           (if (>= i n)
-             (persistent! (conj! acc (- len prev)))
-             (if (>= (key-level (aget run i) lzpl) thresh)
-               (recur (inc i) (inc i) (conj! acc (- (inc i) prev)))
-               (recur (inc i) prev acc))))))
+     (-split-on-insert [_ run len ins level]
+       (let [thresh (inc level)]
+         (if (< ins (dec len))
+           (when (>= (key-level (aget run ins) lzpl) thresh)
+             [(inc ins) (- len (inc ins))])
+           (when (and (>= len 2) (>= (key-level (aget run (- len 2)) lzpl) thresh))
+             [(dec len) 1]))))
      (-content-defined? [_] true)))
 
 #?(:cljs

--- a/src-clojure/org/replikativ/persistent_sorted_set/boundary.cljc
+++ b/src-clojure/org/replikativ/persistent_sorted_set/boundary.cljc
@@ -68,7 +68,9 @@
                  (int-array [(inc ins) (- len (inc ins))]))
                (when (and (>= len 2) (>= (key-level (aget ^objects run (- len 2)) lzpl) thresh))
                  (int-array [(dec len) 1])))))
-         (contentDefined [_] true)))))
+         (contentDefined [_] true)
+         ;; self-describing: rides in the fressian blob so a restored store rebuilds this policy.
+         (descriptor [_] {:type :mst :lzpl lzpl})))))
 
 ;; ---- CLJS: implement the PBoundary protocol -------------------------------------------
 
@@ -83,10 +85,25 @@
              [(inc ins) (- len (inc ins))])
            (when (and (>= len 2) (>= (key-level (aget run (- len 2)) lzpl) thresh))
              [(dec len) 1]))))
-     (-content-defined? [_] true)))
+     (-content-defined? [_] true)
+     (-descriptor [_] {:type :mst :lzpl lzpl})))
 
 #?(:cljs
    (defn mst-boundary
      "Build an MST PBoundary (cljs). `lzpl` sets target fanout (avg node ≈ 2^lzpl keys)."
      [lzpl]
      (->MstBoundary (max 1 lzpl))))
+
+;; ---- reconstruct a boundary from its serialized descriptor (the fressian :boundary-resolver) ----
+
+(defn boundary-from-descriptor
+  "Rebuild an IBoundary/PBoundary from the descriptor stored in a node blob. Pass this as
+   `:boundary-resolver` to the fressian read-handlers so a durable MST store self-restores."
+  [descriptor]
+  (case (:type descriptor)
+    :mst (mst-boundary (:lzpl descriptor))
+    (throw (ex-info "Unknown boundary descriptor type" {:descriptor descriptor}))))
+
+;; cljs has no dynamic require, so register the resolver with the lightweight impl ns on load
+;; (the JVM resolves via requiring-resolve and needs no registration).
+#?(:cljs (b/register-resolver! boundary-from-descriptor))

--- a/src-clojure/org/replikativ/persistent_sorted_set/branch.cljs
+++ b/src-clojure/org/replikativ/persistent_sorted_set/branch.cljs
@@ -719,7 +719,15 @@
                              children      (ensure-children this)
                              addrs         (.-addresses this)
                              last-child?   (== idx (dec (arrays/alength keys)))
-                             max-key-changed (and last-child? (not (== 0 (cmp new-max-key (arrays/aget keys idx)))))]
+                             ;; split-seam (MST): the separator keys[idx] must equal the child's max for
+                             ;; canonical content-addressing, so ANY value change (even at the same
+                             ;; comparator position, and for a non-rightmost child) must rebuild keys[idx]
+                             ;; and propagate up the spine. Count mode is routing-only (by cmp), so its
+                             ;; original last-child?/cmp test is preserved byte-for-byte. Mirrors JVM
+                             ;; Branch.replace, which always writes _keys[idx] = newMaxKey.
+                             max-key-changed (if (b/content-boundary settings)
+                                               (not= new-max-key (arrays/aget keys idx))
+                                               (and last-child? (not (== 0 (cmp new-max-key (arrays/aget keys idx))))))]
                          (if max-key-changed
                            ;; maxKey changed - update keys array
                            (if editable?

--- a/src-clojure/org/replikativ/persistent_sorted_set/branch.cljs
+++ b/src-clojure/org/replikativ/persistent_sorted_set/branch.cljs
@@ -430,34 +430,35 @@
   "split-seam (MST): given the merged separators/children after absorbing a child split,
    cut at boundary keys (≤2-way for one incremental insert). Mirrors the JVM Branch.add seam
    path. MST forces diff-buf off, so no slots/addresses bookkeeping (anchorless re-store)."
-  [^Branch this bd new-keys new-children key]
+  [^Branch this bd new-keys new-children ins key]
   (let [settings    (.-settings this)
         lvl         (.-level this)
         measure-ops (:measure settings)
-        total       (arrays/alength new-children)]
-    (if (b/-overflows? bd new-keys total lvl)
-      (let [lens (b/-split-lengths bd new-keys total lvl)]
-        (loop [out (transient []), pos 0, ls lens]
-          (if (seq ls)
-            (let [l    (first ls)
-                  kseg (.slice new-keys pos (+ pos l))
-                  cseg (.slice new-children pos (+ pos l))
-                  m    (when (and measure-ops (.-_measure this))
-                         (reduce (fn [acc child]
-                                   (if (nil? acc)
-                                     (reduced nil)
-                                     (let [cs (node/measure child)]
-                                       (if cs (measure/merge-measure measure-ops acc cs) (reduced nil)))))
-                                 (measure/identity-measure measure-ops) cseg))
-                  sc   (try-compute-subtree-count-from-children cseg l)]
-              (recur (conj! out (Branch. lvl kseg cseg nil sc m settings nil 0 (.-_projCmp this)))
-                     (+ pos l) (next ls)))
-            (arrays/into-array (persistent! out)))))
+        total       (arrays/alength new-children)
+        ;; O(1): the one promoted separator (the split child's new max) is at `ins`.
+        lens        (b/-split-on-insert bd new-keys total ins lvl)]
+    (if (nil? lens)
       (let [old-sc (.-subtree-count this)
             new-sc (if (>= old-sc 0) (inc old-sc) -1)
             m      (when (and measure-ops (.-_measure this))
                      (measure/merge-measure measure-ops (.-_measure this) (measure/extract measure-ops key)))]
-        (arrays/array (Branch. lvl new-keys new-children nil new-sc m settings nil 0 (.-_projCmp this)))))))
+        (arrays/array (Branch. lvl new-keys new-children nil new-sc m settings nil 0 (.-_projCmp this))))
+      (loop [out (transient []), pos 0, ls lens]
+        (if (seq ls)
+          (let [l    (first ls)
+                kseg (.slice new-keys pos (+ pos l))
+                cseg (.slice new-children pos (+ pos l))
+                m    (when (and measure-ops (.-_measure this))
+                       (reduce (fn [acc child]
+                                 (if (nil? acc)
+                                   (reduced nil)
+                                   (let [cs (node/measure child)]
+                                     (if cs (measure/merge-measure measure-ops acc cs) (reduced nil)))))
+                               (measure/identity-measure measure-ops) cseg))
+                sc   (try-compute-subtree-count-from-children cseg l)]
+            (recur (conj! out (Branch. lvl kseg cseg nil sc m settings nil 0 (.-_projCmp this)))
+                   (+ pos l) (next ls)))
+          (arrays/into-array (persistent! out)))))))
 
 (defn add
   [^Branch this storage key cmp opts]
@@ -481,7 +482,7 @@
                            new-children     (util/splice children idx (inc idx) nodes)
                            nodes-len        (arrays/alength nodes)]
                        (if bd
-                         (mst-branch-add this bd new-keys new-children key)
+                         (mst-branch-add this bd new-keys new-children idx key)
                        (if (<= (arrays/alength new-children) branching-factor)
                          (let [new-addrs
                                (when addrs

--- a/src-clojure/org/replikativ/persistent_sorted_set/branch.cljs
+++ b/src-clojure/org/replikativ/persistent_sorted_set/branch.cljs
@@ -483,101 +483,101 @@
                            nodes-len        (arrays/alength nodes)]
                        (if bd
                          (mst-branch-add this bd new-keys new-children idx key)
-                       (if (<= (arrays/alength new-children) branching-factor)
-                         (let [new-addrs
-                               (when addrs
-                                 (if (= nodes-len 1)
-                                   (let [na (arrays/make-array (arrays/alength addrs))]
-                                     (arrays/acopy addrs 0 (arrays/alength addrs) na 0)
+                         (if (<= (arrays/alength new-children) branching-factor)
+                           (let [new-addrs
+                                 (when addrs
+                                   (if (= nodes-len 1)
+                                     (let [na (arrays/make-array (arrays/alength addrs))]
+                                       (arrays/acopy addrs 0 (arrays/alength addrs) na 0)
                                      ;; Mark old child address as freed before clearing. diff-buf:
                                      ;; under diff-buf the old address may be re-pointed as a buffered
                                      ;; anchor at store, so freeing is DEFERRED to store.
-                                     (when (and (not diff-buf?) storage (aget addrs idx))
-                                       (storage/markFreed storage (aget addrs idx)))
-                                     (aset na idx nil)
-                                     na)
-                                   (let [old-addr (aget addrs idx)]
-                                     (when (and (not diff-buf?) storage old-addr)
-                                       (storage/markFreed storage old-addr))
-                                     (util/splice addrs idx (inc idx) (arrays/array nil nil)))))
+                                       (when (and (not diff-buf?) storage (aget addrs idx))
+                                         (storage/markFreed storage (aget addrs idx)))
+                                       (aset na idx nil)
+                                       na)
+                                     (let [old-addr (aget addrs idx)]
+                                       (when (and (not diff-buf?) storage old-addr)
+                                         (storage/markFreed storage old-addr))
+                                       (util/splice addrs idx (inc idx) (arrays/array nil nil)))))
                                ;; After adding one element, increment count if known
-                               old-sc (.-subtree-count this)
-                               new-sc (if (>= old-sc 0) (inc old-sc) -1)
+                                 old-sc (.-subtree-count this)
+                                 new-sc (if (>= old-sc 0) (inc old-sc) -1)
                                ;; Update measure incrementally only if already computed
-                               measure-ops (:measure (.-settings this))
-                               new-measure (when (and measure-ops (.-_measure this))
-                                             (measure/merge-measure measure-ops (.-_measure this) (measure/extract measure-ops key)))
-                               nb (Branch. (.-level this) new-keys new-children new-addrs new-sc new-measure (.-settings this) nil 0 (.-_projCmp this))]
+                                 measure-ops (:measure (.-settings this))
+                                 new-measure (when (and measure-ops (.-_measure this))
+                                               (measure/merge-measure measure-ops (.-_measure this) (measure/extract measure-ops key)))
+                                 nb (Branch. (.-level this) new-keys new-children new-addrs new-sc new-measure (.-settings this) nil 0 (.-_projCmp this))]
                            ;; diff-buf: nodes-len==1 ⇒ content-only ⇒ carry the source slots and
                            ;; deposit Present(key) (matches JVM persistent path). nodes-len>=2 ⇒ a child
                            ;; split was absorbed ⇒ structural: mark rebalanced + stitch surviving siblings.
-                           (when diff-buf?
-                             (if (= nodes-len 1)
-                               (do (set! (.-_bufEntries nb) (buf-entries this)) ; carry running total (or -1) onto successor
-                                   (await (carry-and-deposit nb storage (.-_slots this) idx key key anchor0 opts)))
-                               (do (set! (.-_bufEntries nb) -1) ; absorbed a child split: structural → must write
-                                   (free-dropped-child this storage idx) ; diff-buf: free the split child's old blob
-                                   (set! (.-_slots nb) (stitch-slots this idx nodes-len (arrays/alength new-children))))))
-                           (arrays/array nb))
-                         (let [middle      (arrays/half (arrays/alength new-children))
-                               tmp-addrs   (when addrs
-                                             (let [old-addr (aget addrs idx)]
+                             (when diff-buf?
+                               (if (= nodes-len 1)
+                                 (do (set! (.-_bufEntries nb) (buf-entries this)) ; carry running total (or -1) onto successor
+                                     (await (carry-and-deposit nb storage (.-_slots this) idx key key anchor0 opts)))
+                                 (do (set! (.-_bufEntries nb) -1) ; absorbed a child split: structural → must write
+                                     (free-dropped-child this storage idx) ; diff-buf: free the split child's old blob
+                                     (set! (.-_slots nb) (stitch-slots this idx nodes-len (arrays/alength new-children))))))
+                             (arrays/array nb))
+                           (let [middle      (arrays/half (arrays/alength new-children))
+                                 tmp-addrs   (when addrs
+                                               (let [old-addr (aget addrs idx)]
                                                ;; Mark old child address as freed before clearing (deferred under diff-buf)
-                                               (when (and (not diff-buf?) storage old-addr)
-                                                 (storage/markFreed storage old-addr))
-                                               (util/splice addrs idx (inc idx) (arrays/array nil nil))))
-                               left-addrs  (when tmp-addrs (.slice tmp-addrs 0 middle))
-                               right-addrs (when tmp-addrs (.slice tmp-addrs middle))
-                               left-children (.slice new-children 0 middle)
-                               right-children (.slice new-children middle)
-                               measure-ops (:measure (.-settings this))
+                                                 (when (and (not diff-buf?) storage old-addr)
+                                                   (storage/markFreed storage old-addr))
+                                                 (util/splice addrs idx (inc idx) (arrays/array nil nil))))
+                                 left-addrs  (when tmp-addrs (.slice tmp-addrs 0 middle))
+                                 right-addrs (when tmp-addrs (.slice tmp-addrs middle))
+                                 left-children (.slice new-children 0 middle)
+                                 right-children (.slice new-children middle)
+                                 measure-ops (:measure (.-settings this))
                                ;; Compute measure for split branches from their children only if already computed
                                ;; Return nil if any child measure is nil (don't silently undercount)
-                               left-measure (when (and measure-ops (.-_measure this))
-                                              (reduce (fn [acc child]
-                                                        (if (nil? acc)
-                                                          (reduced nil)
-                                                          (let [cs (node/measure child)]
-                                                            (if cs
-                                                              (measure/merge-measure measure-ops acc cs)
-                                                              (reduced nil)))))
-                                                      (measure/identity-measure measure-ops)
-                                                      left-children))
-                               right-measure (when (and measure-ops (.-_measure this))
-                                               (reduce (fn [acc child]
-                                                         (if (nil? acc)
-                                                           (reduced nil)
-                                                           (let [cs (node/measure child)]
-                                                             (if cs
-                                                               (measure/merge-measure measure-ops acc cs)
-                                                               (reduced nil)))))
-                                                       (measure/identity-measure measure-ops)
-                                                       right-children))
-                               new-len (arrays/alength new-children)
-                               left-b  (Branch. (.-level this)
-                                                (.slice new-keys 0 middle)
-                                                left-children
-                                                left-addrs
-                                                (try-compute-subtree-count-from-children left-children (arrays/alength left-children))
-                                                left-measure
-                                                (.-settings this) nil 0 (.-_projCmp this))
-                               right-b (Branch. (.-level this)
-                                                (.slice new-keys middle)
-                                                right-children
-                                                right-addrs
-                                                (try-compute-subtree-count-from-children right-children (arrays/alength right-children))
-                                                right-measure
-                                                (.-settings this) nil 0 (.-_projCmp this))]
+                                 left-measure (when (and measure-ops (.-_measure this))
+                                                (reduce (fn [acc child]
+                                                          (if (nil? acc)
+                                                            (reduced nil)
+                                                            (let [cs (node/measure child)]
+                                                              (if cs
+                                                                (measure/merge-measure measure-ops acc cs)
+                                                                (reduced nil)))))
+                                                        (measure/identity-measure measure-ops)
+                                                        left-children))
+                                 right-measure (when (and measure-ops (.-_measure this))
+                                                 (reduce (fn [acc child]
+                                                           (if (nil? acc)
+                                                             (reduced nil)
+                                                             (let [cs (node/measure child)]
+                                                               (if cs
+                                                                 (measure/merge-measure measure-ops acc cs)
+                                                                 (reduced nil)))))
+                                                         (measure/identity-measure measure-ops)
+                                                         right-children))
+                                 new-len (arrays/alength new-children)
+                                 left-b  (Branch. (.-level this)
+                                                  (.slice new-keys 0 middle)
+                                                  left-children
+                                                  left-addrs
+                                                  (try-compute-subtree-count-from-children left-children (arrays/alength left-children))
+                                                  left-measure
+                                                  (.-settings this) nil 0 (.-_projCmp this))
+                                 right-b (Branch. (.-level this)
+                                                  (.slice new-keys middle)
+                                                  right-children
+                                                  right-addrs
+                                                  (try-compute-subtree-count-from-children right-children (arrays/alength right-children))
+                                                  right-measure
+                                                  (.-settings this) nil 0 (.-_projCmp this))]
                            ;; diff-buf: a child split overflowed this branch → split: structural on both
                            ;; halves → written, but each still buffers its surviving siblings' slots.
-                           (when diff-buf?
-                             (set! (.-_bufEntries left-b) -1) ; split: structural on both halves → must write
-                             (set! (.-_bufEntries right-b) -1)
-                             (free-dropped-child this storage idx) ; diff-buf: free the split child's old blob
-                             (when-let [all (stitch-slots this idx nodes-len new-len)]
-                               (set! (.-_slots left-b)  (.slice all 0 middle))
-                               (set! (.-_slots right-b) (.slice all middle))))
-                           (arrays/array left-b right-b)))))))))))
+                             (when diff-buf?
+                               (set! (.-_bufEntries left-b) -1) ; split: structural on both halves → must write
+                               (set! (.-_bufEntries right-b) -1)
+                               (free-dropped-child this storage idx) ; diff-buf: free the split child's old blob
+                               (when-let [all (stitch-slots this idx nodes-len new-len)]
+                                 (set! (.-_slots left-b)  (.slice all 0 middle))
+                                 (set! (.-_slots right-b) (.slice all middle))))
+                             (arrays/array left-b right-b)))))))))))
 
 (defn $remove
   [^Branch this storage key left right cmp {:keys [sync?] :or {sync? true} :as opts}]

--- a/src-clojure/org/replikativ/persistent_sorted_set/branch.cljs
+++ b/src-clojure/org/replikativ/persistent_sorted_set/branch.cljs
@@ -6,6 +6,7 @@
             [org.replikativ.persistent-sorted-set.impl.node :as node :refer [INode]]
             [org.replikativ.persistent-sorted-set.impl.measure :as measure]
             [org.replikativ.persistent-sorted-set.impl.storage :as storage]
+            [org.replikativ.persistent-sorted-set.impl.boundary :as b]
             [org.replikativ.persistent-sorted-set.leaf :refer [Leaf]]
             [org.replikativ.persistent-sorted-set.util :as util]))
 
@@ -425,6 +426,39 @@
           (when (and sl (some? (:anchor sl)))
             (storage/markFreed storage (:anchor sl))))))))
 
+(defn- mst-branch-add
+  "split-seam (MST): given the merged separators/children after absorbing a child split,
+   cut at boundary keys (≤2-way for one incremental insert). Mirrors the JVM Branch.add seam
+   path. MST forces diff-buf off, so no slots/addresses bookkeeping (anchorless re-store)."
+  [^Branch this bd new-keys new-children key]
+  (let [settings    (.-settings this)
+        lvl         (.-level this)
+        measure-ops (:measure settings)
+        total       (arrays/alength new-children)]
+    (if (b/-overflows? bd new-keys total lvl)
+      (let [lens (b/-split-lengths bd new-keys total lvl)]
+        (loop [out (transient []), pos 0, ls lens]
+          (if (seq ls)
+            (let [l    (first ls)
+                  kseg (.slice new-keys pos (+ pos l))
+                  cseg (.slice new-children pos (+ pos l))
+                  m    (when (and measure-ops (.-_measure this))
+                         (reduce (fn [acc child]
+                                   (if (nil? acc)
+                                     (reduced nil)
+                                     (let [cs (node/measure child)]
+                                       (if cs (measure/merge-measure measure-ops acc cs) (reduced nil)))))
+                                 (measure/identity-measure measure-ops) cseg))
+                  sc   (try-compute-subtree-count-from-children cseg l)]
+              (recur (conj! out (Branch. lvl kseg cseg nil sc m settings nil 0 (.-_projCmp this)))
+                     (+ pos l) (next ls)))
+            (arrays/into-array (persistent! out)))))
+      (let [old-sc (.-subtree-count this)
+            new-sc (if (>= old-sc 0) (inc old-sc) -1)
+            m      (when (and measure-ops (.-_measure this))
+                     (measure/merge-measure measure-ops (.-_measure this) (measure/extract measure-ops key)))]
+        (arrays/array (Branch. lvl new-keys new-children nil new-sc m settings nil 0 (.-_projCmp this)))))))
+
 (defn add
   [^Branch this storage key cmp opts]
   (let [{:keys [sync?] :or {sync? true}} opts
@@ -441,10 +475,13 @@
                        nodes      (await (node/add child-node storage key cmp opts))]
                    (when nodes
                      (let [branching-factor (:branching-factor (.-settings this))
+                           bd               (b/content-boundary (.-settings this))
                            children         (ensure-children this)
                            new-keys         (util/check-n-splice cmp keys idx (inc idx) (arrays/amap node/max-key nodes))
                            new-children     (util/splice children idx (inc idx) nodes)
                            nodes-len        (arrays/alength nodes)]
+                       (if bd
+                         (mst-branch-add this bd new-keys new-children key)
                        (if (<= (arrays/alength new-children) branching-factor)
                          (let [new-addrs
                                (when addrs
@@ -539,7 +576,7 @@
                              (when-let [all (stitch-slots this idx nodes-len new-len)]
                                (set! (.-_slots left-b)  (.slice all 0 middle))
                                (set! (.-_slots right-b) (.slice all middle))))
-                           (arrays/array left-b right-b))))))))))
+                           (arrays/array left-b right-b)))))))))))
 
 (defn $remove
   [^Branch this storage key left right cmp {:keys [sync?] :or {sync? true} :as opts}]

--- a/src-clojure/org/replikativ/persistent_sorted_set/btset.cljs
+++ b/src-clojure/org/replikativ/persistent_sorted_set/btset.cljs
@@ -9,6 +9,7 @@
             [org.replikativ.persistent-sorted-set.impl.node :as node]
             [org.replikativ.persistent-sorted-set.impl.measure :as measure]
             [org.replikativ.persistent-sorted-set.impl.storage :as storage]
+            [org.replikativ.persistent-sorted-set.impl.boundary :as b]
             [org.replikativ.persistent-sorted-set.util :refer [rotate lookup-exact splice cut-n-splice binary-search-l binary-search-r return-array merge-n-split check-n-splice]]))
 
 (declare BTSet)
@@ -48,6 +49,117 @@
                (let [root (await (-root set opts))]
                  (await (node/$contains? root (.-storage set) key (.-comparator set) opts))))))
 
+;; ---- split-seam (MST / content-defined boundary) --------------------------------------
+;; Parallel of the JVM PersistentSortedSet.growRoot + ANode.removeContent/mstMergeWith.
+;; MST forces diff-buf off, so these build anchorless branches (no slots/addresses).
+
+(defn- mst-build-branch
+  "Build a level-`lvl` Branch from a seq of child nodes."
+  [lvl children-seq settings projcmp]
+  (let [carr          (arrays/into-array children-seq)
+        child-counts  (map node/subtree-count children-seq)
+        subtree-count (if (every? #(>= % 0) child-counts) (reduce + 0 child-counts) -1)
+        measure-ops   (:measure settings)
+        cmeas         (when measure-ops (map node/measure children-seq))
+        measure       (when (and measure-ops (every? some? cmeas))
+                        (reduce (fn [acc cs] (measure/merge-measure measure-ops acc cs))
+                                (measure/identity-measure measure-ops) cmeas))]
+    (Branch. lvl (arrays/amap node/max-key carr) carr nil subtree-count measure settings nil 0 projcmp)))
+
+(defn- mst-children
+  "Vector of a branch's (materialized) children. MST is storage-light: in-memory children are
+   populated directly. (Storage-backed MST remove — needing async restore — is a follow-up.)"
+  [^Branch node]
+  (let [ch (.-children node) n (arrays/alength (.-keys node))]
+    (mapv #(aget ch %) (range n))))
+
+(declare mst-merge-with mst-remove-content)
+
+(defn- mst-merge-with
+  "Combine two same-level nodes whose separating (removed) boundary is gone. The junction —
+   a's last child with b's first child — merges recursively ONLY when a's last child ended at
+   that removed boundary (its maxKey is no longer a boundary at its level). If a's last child
+   is still terminated by a LIVE boundary (e.g. a's deepest boundary leaf was dropped, leaving
+   a's tail a properly-terminated leaf), the two must NOT fuse — plain concatenation keeps the
+   live boundary. The inverse of add's promotion (≡ JVM ANode.mstMergeWith)."
+  [a b projcmp bd]
+  (if (instance? Leaf a)
+    ;; reached as a junction ⇒ a ended at the removed boundary (level 0) ⇒ concatenate
+    (let [settings    (.-settings a)
+          measure-ops (:measure settings)
+          lf          (Leaf. (arrays/aconcat (.-keys a) (.-keys b)) settings nil)]
+      (when measure-ops (node/try-compute-measure lf nil measure-ops {:sync? true}))
+      lf)
+    (let [a-ch (mst-children a)
+          b-ch (mst-children b)]
+      (if (>= (b/-key-level bd (node/max-key a)) (.-level a))
+        ;; a's last child is a live boundary ⇒ keep it; just concatenate the child lists.
+        (mst-build-branch (.-level a) (concat a-ch b-ch) (.-settings a) projcmp)
+        ;; a's last child ended at the removed boundary ⇒ merge the junction.
+        (let [junction (mst-merge-with (last a-ch) (first b-ch) projcmp bd)]
+          (mst-build-branch (.-level a) (concat (butlast a-ch) [junction] (rest b-ch))
+                            (.-settings a) projcmp))))))
+
+(defn- mst-remove-content
+  "MST remove without sibling-passing: returns the modified subtree (one node, possibly an
+   empty Leaf), or nil if key absent. A Branch merges two of its own children when the removed
+   key was a boundary at its level; the cross-parent case is handled by the grandparent.
+   Synchronous (≡ JVM ANode.removeContent)."
+  [node key cmp projcmp]
+  (if (instance? Leaf node)
+    (let [keys (.-keys node)
+          idx  (lookup-exact cmp keys key)]
+      (when (>= idx 0)
+        (let [settings    (.-settings node)
+              measure-ops (:measure settings)
+              lf          (Leaf. (splice keys idx (inc idx) (arrays/array)) settings nil)]
+          (when measure-ops (node/try-compute-measure lf nil measure-ops {:sync? true}))
+          lf)))
+    (let [keys (.-keys node)
+          n    (arrays/alength keys)
+          idx  (binary-search-l cmp keys (dec n) key)]
+      (if (== idx n)
+        nil
+        (let [children  (mst-children node)
+              new-child (mst-remove-content (nth children idx) key cmp projcmp)]
+          (if (nil? new-child)
+            nil
+            (let [bd          (b/content-boundary (.-settings node))
+                  lvl         (.-level node)
+                  empty-leaf? (and (instance? Leaf new-child) (== 0 (arrays/alength (.-keys new-child))))
+                  merge-right? (and (< idx (dec n)) (>= (b/-key-level bd key) lvl))
+                  new-children (cond
+                                 empty-leaf?  (concat (take idx children) (drop (inc idx) children))
+                                 merge-right? (let [merged (mst-merge-with new-child (nth children (inc idx)) projcmp bd)]
+                                                (concat (take idx children) [merged] (drop (+ idx 2) children)))
+                                 :else        (concat (take idx children) [new-child] (drop (inc idx) children)))]
+              (if (seq new-children)
+                (mst-build-branch lvl new-children (.-settings node) projcmp)
+                (Leaf. (arrays/array) (.-settings node) nil)))))))))
+
+(defn- mst-grow-root
+  "Promote sibling roots by boundary level until one remains (multi-level for high-level keys)."
+  [bd nodes settings projcmp]
+  (loop [nodes nodes]
+    (let [n (arrays/alength nodes)]
+      (if (< n 2)
+        (arrays/aget nodes 0)
+        (let [lvl    (inc (node/level (arrays/aget nodes 0)))
+              thresh (inc lvl)
+              branches
+              (loop [i 0 start 0 out (transient [])]
+                (if (>= i n)
+                  (persistent! out)
+                  (let [cut (and (< i (dec n))
+                                 (>= (b/-key-level bd (node/max-key (arrays/aget nodes i))) thresh))]
+                    (if (or cut (== i (dec n)))
+                      (recur (inc i) (inc i)
+                             (conj! out (mst-build-branch lvl (array-seq (.slice nodes start (inc i))) settings projcmp)))
+                      (recur (inc i) start out)))))]
+          (if (== 1 (count branches))
+            (first branches)
+            (recur (arrays/into-array branches))))))))
+
 (defn conjoin
   ([^BTSet set key]
    (conjoin set key (.-comparator set) {:sync? true}))
@@ -80,6 +192,11 @@
                                   (.-storage set)
                                   nil
                                   (.-settings set))
+                          (if-let [bd (b/content-boundary (.-settings set))]
+                            ;; split-seam (MST): multi-level boundary promotion (≡ JVM growRoot)
+                            (BTSet. (mst-grow-root bd roots (.-settings set) (.-comparator set))
+                                    new-cnt (.-comparator set) (.-meta set)
+                                    UNINITIALIZED_HASH (.-storage set) nil (.-settings set))
                           (let [child0 (arrays/aget roots 0)
                                 lvl    (inc (node/level child0))
                                 ;; Compute subtree count; propagate -1 (unknown) if any child is unknown
@@ -107,7 +224,7 @@
                                     UNINITIALIZED_HASH
                                     (.-storage set)
                                     nil
-                                    (.-settings set))))))))))))
+                                    (.-settings set)))))))))))))
 
 (defn $replace
   ([^BTSet set old-key new-key]
@@ -163,29 +280,49 @@
    (async+sync sync?
                (async
                 (let [root (await (-root set opts))
-                      new-roots (await (node/$remove root (.-storage set) key nil nil cmp opts))]
-                  (if (nil? new-roots)
-                    set
-                    (do
-                      ;; Mark old root address as freed if it exists
-                      (when (and (.-storage set) (.-address set))
-                        (storage/markFreed (.-storage set) (.-address set)))
-                      (let [new-root (arrays/aget new-roots 0)
-                            new-root (if (and (instance? Branch new-root)
-                                              (== 1 (arrays/alength (.-children new-root))))
-                                       (await (branch/child new-root (.-storage set) 0 opts))
-                                       new-root)
-                            ;; If count is unknown (-1), keep it unknown; will be computed lazily when needed
-                            current-cnt (.-cnt set)
-                            new-cnt (if (neg? current-cnt) -1 (dec current-cnt))]
-                        (BTSet. new-root
-                                new-cnt
-                                (.-comparator set)
-                                (.-meta set)
-                                UNINITIALIZED_HASH
-                                (.-storage set)
-                                nil
-                                (.-settings set))))))))))
+                      bd   (b/content-boundary (.-settings set))]
+                  (if bd
+                    ;; split-seam (MST): sibling-free removeContent + single-child root collapse
+                    ;; (≡ JVM disjoin content branch). Synchronous (in-memory MST).
+                    (let [new-root (mst-remove-content root key cmp (.-comparator set))]
+                      (if (nil? new-root)
+                        set
+                        (do
+                          (when (and (.-storage set) (.-address set))
+                            (storage/markFreed (.-storage set) (.-address set)))
+                          (let [new-root (loop [r new-root]
+                                           (if (and (instance? Branch r)
+                                                    (== 1 (arrays/alength (.-keys r))))
+                                             (recur (aget (.-children r) 0))
+                                             r))
+                                current-cnt (.-cnt set)
+                                new-cnt (if (neg? current-cnt) -1 (dec current-cnt))]
+                            (BTSet. new-root new-cnt (.-comparator set) (.-meta set)
+                                    UNINITIALIZED_HASH (.-storage set) nil (.-settings set))))))
+                    ;; count path (unchanged)
+                    (let [new-roots (await (node/$remove root (.-storage set) key nil nil cmp opts))]
+                      (if (nil? new-roots)
+                        set
+                        (do
+                          ;; Mark old root address as freed if it exists
+                          (when (and (.-storage set) (.-address set))
+                            (storage/markFreed (.-storage set) (.-address set)))
+                          (let [new-root (arrays/aget new-roots 0)
+                                new-root (if (and (instance? Branch new-root)
+                                                  (== 1 (arrays/alength (.-children new-root))))
+                                           (await (branch/child new-root (.-storage set) 0 opts))
+                                           new-root)
+                                ;; If count is unknown (-1), keep it unknown; will be computed lazily when needed
+                                current-cnt (.-cnt set)
+                                new-cnt (if (neg? current-cnt) -1 (dec current-cnt))]
+                            (BTSet. new-root
+                                    new-cnt
+                                    (.-comparator set)
+                                    (.-meta set)
+                                    UNINITIALIZED_HASH
+                                    (.-storage set)
+                                    nil
+                                    (.-settings set))))))))))))
 
 (defn store
   ([^BTSet set arg]
@@ -1584,19 +1721,52 @@
         (recur (inc i))))
     arr))
 
+(declare from-sorted-array-count)
+
+(defn- mst-partition
+  "Bulk MST partition: cut arr[0..n) into JS-array segments after each index i<n-1 whose
+   (key-of arr[i]) rises to thresh (= node-level+1). Mirrors the JVM mst-split."
+  [bd arr key-of thresh]
+  (let [n (arrays/alength arr)
+        last-i (dec n)]
+    (loop [i 0 start 0 out (transient [])]
+      (if (>= i n)
+        (persistent! (if (> n start) (conj! out (.slice arr start n)) out))
+        (if (and (< i last-i) (>= (b/-key-level bd (key-of (aget arr i))) thresh))
+          (recur (inc i) (inc i) (conj! out (.slice arr start (inc i))))
+          (recur (inc i) start out))))))
+
 (defn ^BTSet from-sorted-array
   [cmp arr _len opts]
-  (let [settings (select-keys opts [:branching-factor :measure])
+  (let [settings (select-keys opts [:branching-factor :measure :boundary])
         measure-ops (:measure settings)
-        set      (BTSet. nil 0 cmp nil nil nil nil settings)
+        storage  (:storage opts)
+        bd       (b/content-boundary settings)]
+    (if bd
+      ;; split-seam (MST): chunk by boundary level so bulk == incremental (≡ JVM mst-split).
+      (let [leaves (mapv #(let [leaf (Leaf. % settings nil)]
+                            (when measure-ops (node/try-compute-measure leaf nil measure-ops {:sync? true}))
+                            leaf)
+                         (mst-partition bd arr identity 1))]
+        (loop [nodes leaves, lvl 1]
+          (case (count nodes)
+            0 (BTSet. (Leaf. (arrays/array) settings nil) 0 cmp nil UNINITIALIZED_HASH storage nil settings)
+            1 (BTSet. (first nodes) (arrays/alength arr) cmp nil UNINITIALIZED_HASH storage nil settings)
+            (recur (mapv #(mst-build-branch lvl (array-seq %) settings cmp)
+                         (mst-partition bd (arrays/into-array nodes) node/max-key (inc lvl)))
+                   (inc lvl)))))
+      (from-sorted-array-count cmp arr _len settings storage measure-ops))))
+
+(defn- ^BTSet from-sorted-array-count
+  [cmp arr _len settings storage measure-ops]
+  (let [set      (BTSet. nil 0 cmp nil nil nil nil settings)
         leaves   (->> arr
                       (arr-partition-approx set)
                       (arr-map-inplace #(let [leaf (Leaf. % settings nil)]
                                           ;; Compute measure for leaf if measure-ops available
                                           (when measure-ops
                                             (node/try-compute-measure leaf nil measure-ops {:sync? true}))
-                                          leaf)))
-        storage  (:storage opts)]
+                                          leaf)))]
     (loop [current-level leaves
            shift 0]
       (case (count current-level)
@@ -1641,7 +1811,7 @@
    - :measure  Measure implementation (IMeasure protocol)
    - :meta     Metadata"
   [opts]
-  (let [settings (select-keys opts [:branching-factor :measure])]
+  (let [settings (select-keys opts [:branching-factor :measure :boundary])]
     (BTSet. (Leaf. (arrays/array) settings nil) 0 (or (:comparator opts) (:cmp opts) compare)
             (:meta opts) UNINITIALIZED_HASH (:storage opts) nil settings)))
 

--- a/src-clojure/org/replikativ/persistent_sorted_set/btset.cljs
+++ b/src-clojure/org/replikativ/persistent_sorted_set/btset.cljs
@@ -82,14 +82,14 @@
    address is the child's durable address (nil if unstored), preserved on rebuild."
   [^Branch node storage {:keys [sync?] :or {sync? true} :as opts}]
   (async+sync sync?
-   (async
-    (let [n (arrays/alength (.-keys node))]
-      (loop [i 0 cs (transient []) as (transient [])]
-        (if (< i n)
-          (recur (inc i)
-                 (conj! cs (await (branch/child node storage i opts)))
-                 (conj! as (branch/address node i)))
-          [(persistent! cs) (persistent! as)]))))))
+              (async
+               (let [n (arrays/alength (.-keys node))]
+                 (loop [i 0 cs (transient []) as (transient [])]
+                   (if (< i n)
+                     (recur (inc i)
+                            (conj! cs (await (branch/child node storage i opts)))
+                            (conj! as (branch/address node i)))
+                     [(persistent! cs) (persistent! as)]))))))
 
 (declare mst-merge-with mst-remove-content)
 
@@ -101,78 +101,78 @@
    ANode.mstMergeWith). Returns (async node)."
   [a b projcmp bd storage {:keys [sync?] :or {sync? true} :as opts}]
   (async+sync sync?
-   (async
-    (if (instance? Leaf a)
+              (async
+               (if (instance? Leaf a)
      ;; reached as a junction ⇒ a ended at the removed boundary (level 0) ⇒ concatenate
-     (let [settings    (.-settings a)
-           measure-ops (:measure settings)
-           lf          (Leaf. (arrays/aconcat (.-keys a) (.-keys b)) settings nil)]
-       (when measure-ops (node/try-compute-measure lf nil measure-ops {:sync? true}))
-       lf)
-     (let [[a-ch a-ad] (await (mst-children a storage opts))
-           [b-ch b-ad] (await (mst-children b storage opts))]
-       (if (>= (b/-key-level bd (node/max-key a)) (.-level a))
+                 (let [settings    (.-settings a)
+                       measure-ops (:measure settings)
+                       lf          (Leaf. (arrays/aconcat (.-keys a) (.-keys b)) settings nil)]
+                   (when measure-ops (node/try-compute-measure lf nil measure-ops {:sync? true}))
+                   lf)
+                 (let [[a-ch a-ad] (await (mst-children a storage opts))
+                       [b-ch b-ad] (await (mst-children b storage opts))]
+                   (if (>= (b/-key-level bd (node/max-key a)) (.-level a))
          ;; a's last child is a live boundary ⇒ keep it; concatenate (all addresses preserved).
-         (mst-build-branch (.-level a) (concat a-ch b-ch) (.-settings a) projcmp (concat a-ad b-ad))
+                     (mst-build-branch (.-level a) (concat a-ch b-ch) (.-settings a) projcmp (concat a-ad b-ad))
          ;; a's last child ended at the removed boundary ⇒ merge the junction (consumed inputs freed).
-         (let [junction (await (mst-merge-with (last a-ch) (first b-ch) projcmp bd storage opts))]
-           (free-addr storage (last a-ad))
-           (free-addr storage (first b-ad))
-           (mst-build-branch (.-level a)
-                             (concat (butlast a-ch) [junction] (rest b-ch))
-                             (.-settings a) projcmp
-                             (concat (butlast a-ad) [nil] (rest b-ad))))))))))
+                     (let [junction (await (mst-merge-with (last a-ch) (first b-ch) projcmp bd storage opts))]
+                       (free-addr storage (last a-ad))
+                       (free-addr storage (first b-ad))
+                       (mst-build-branch (.-level a)
+                                         (concat (butlast a-ch) [junction] (rest b-ch))
+                                         (.-settings a) projcmp
+                                         (concat (butlast a-ad) [nil] (rest b-ad))))))))))
 
 (defn- mst-remove-content
   "MST remove without sibling-passing: returns (async <modified subtree, or empty Leaf>) or
    (async nil) if key absent. Storage-aware + address-preserving (≡ JVM ANode.removeContent)."
   [node storage key cmp projcmp {:keys [sync?] :or {sync? true} :as opts}]
   (async+sync sync?
-   (async
-    (if (instance? Leaf node)
-     (let [keys (.-keys node)
-           idx  (lookup-exact cmp keys key)]
-       (when (>= idx 0)
-         (let [settings    (.-settings node)
-               measure-ops (:measure settings)
-               lf          (Leaf. (splice keys idx (inc idx) (arrays/array)) settings nil)]
-           (when measure-ops (node/try-compute-measure lf nil measure-ops {:sync? true}))
-           lf)))
-     (let [keys (.-keys node)
-           n    (arrays/alength keys)
-           idx  (binary-search-l cmp keys (dec n) key)]
-       (if (== idx n)
-         nil
-         (let [[children addrs] (await (mst-children node storage opts))
-               new-child        (await (mst-remove-content (nth children idx) storage key cmp projcmp opts))]
-           (if (nil? new-child)
-             nil
-             (let [bd          (b/content-boundary (.-settings node))
-                   lvl         (.-level node)
-                   settings    (.-settings node)
-                   empty-leaf? (and (instance? Leaf new-child) (== 0 (arrays/alength (.-keys new-child))))
-                   merge-right? (and (< idx (dec n)) (>= (b/-key-level bd key) lvl))]
-               (cond
-                 empty-leaf?
-                 (do (free-addr storage (nth addrs idx))
-                     (let [nc (concat (take idx children) (drop (inc idx) children))
-                           na (concat (take idx addrs) (drop (inc idx) addrs))]
-                       (if (seq nc) (mst-build-branch lvl nc settings projcmp na)
-                           (Leaf. (arrays/array) settings nil))))
-                 merge-right?
-                 (let [merged (await (mst-merge-with new-child (nth children (inc idx)) projcmp bd storage opts))]
-                   (free-addr storage (nth addrs idx))
-                   (free-addr storage (nth addrs (inc idx)))
-                   (mst-build-branch lvl
-                                     (concat (take idx children) [merged] (drop (+ idx 2) children))
-                                     settings projcmp
-                                     (concat (take idx addrs) [nil] (drop (+ idx 2) addrs))))
-                 :else
-                 (do (free-addr storage (nth addrs idx))
-                     (mst-build-branch lvl
-                                       (concat (take idx children) [new-child] (drop (inc idx) children))
-                                       settings projcmp
-                                       (concat (take idx addrs) [nil] (drop (inc idx) addrs))))))))))))))
+              (async
+               (if (instance? Leaf node)
+                 (let [keys (.-keys node)
+                       idx  (lookup-exact cmp keys key)]
+                   (when (>= idx 0)
+                     (let [settings    (.-settings node)
+                           measure-ops (:measure settings)
+                           lf          (Leaf. (splice keys idx (inc idx) (arrays/array)) settings nil)]
+                       (when measure-ops (node/try-compute-measure lf nil measure-ops {:sync? true}))
+                       lf)))
+                 (let [keys (.-keys node)
+                       n    (arrays/alength keys)
+                       idx  (binary-search-l cmp keys (dec n) key)]
+                   (if (== idx n)
+                     nil
+                     (let [[children addrs] (await (mst-children node storage opts))
+                           new-child        (await (mst-remove-content (nth children idx) storage key cmp projcmp opts))]
+                       (if (nil? new-child)
+                         nil
+                         (let [bd          (b/content-boundary (.-settings node))
+                               lvl         (.-level node)
+                               settings    (.-settings node)
+                               empty-leaf? (and (instance? Leaf new-child) (== 0 (arrays/alength (.-keys new-child))))
+                               merge-right? (and (< idx (dec n)) (>= (b/-key-level bd key) lvl))]
+                           (cond
+                             empty-leaf?
+                             (do (free-addr storage (nth addrs idx))
+                                 (let [nc (concat (take idx children) (drop (inc idx) children))
+                                       na (concat (take idx addrs) (drop (inc idx) addrs))]
+                                   (if (seq nc) (mst-build-branch lvl nc settings projcmp na)
+                                       (Leaf. (arrays/array) settings nil))))
+                             merge-right?
+                             (let [merged (await (mst-merge-with new-child (nth children (inc idx)) projcmp bd storage opts))]
+                               (free-addr storage (nth addrs idx))
+                               (free-addr storage (nth addrs (inc idx)))
+                               (mst-build-branch lvl
+                                                 (concat (take idx children) [merged] (drop (+ idx 2) children))
+                                                 settings projcmp
+                                                 (concat (take idx addrs) [nil] (drop (+ idx 2) addrs))))
+                             :else
+                             (do (free-addr storage (nth addrs idx))
+                                 (mst-build-branch lvl
+                                                   (concat (take idx children) [new-child] (drop (inc idx) children))
+                                                   settings projcmp
+                                                   (concat (take idx addrs) [nil] (drop (inc idx) addrs))))))))))))))
 
 (defn- mst-grow-root
   "Promote sibling roots by boundary level until one remains (multi-level for high-level keys)."
@@ -234,34 +234,34 @@
                             (BTSet. (mst-grow-root bd roots (.-settings set) (.-comparator set))
                                     new-cnt (.-comparator set) (.-meta set)
                                     UNINITIALIZED_HASH (.-storage set) nil (.-settings set))
-                          (let [child0 (arrays/aget roots 0)
-                                lvl    (inc (node/level child0))
+                            (let [child0 (arrays/aget roots 0)
+                                  lvl    (inc (node/level child0))
                                 ;; Compute subtree count; propagate -1 (unknown) if any child is unknown
-                                child-counts (map node/subtree-count roots)
-                                subtree-count (if (every? #(>= % 0) child-counts)
-                                                (reduce + 0 child-counts)
-                                                -1)
+                                  child-counts (map node/subtree-count roots)
+                                  subtree-count (if (every? #(>= % 0) child-counts)
+                                                  (reduce + 0 child-counts)
+                                                  -1)
                                 ;; Compute measure from children if measure-ops available
-                                measure-ops (:measure (.-settings set))
+                                  measure-ops (:measure (.-settings set))
                                 ;; Only compute root-measure when all children have measure;
                                 ;; otherwise keep nil to allow lazy recomputation
-                                child-measure (when measure-ops (map node/measure roots))
-                                root-measure (when (and measure-ops (every? some? child-measure))
-                                               (reduce (fn [acc cs]
-                                                         (measure/merge-measure measure-ops acc cs))
-                                                       (measure/identity-measure measure-ops)
-                                                       child-measure))]
+                                  child-measure (when measure-ops (map node/measure roots))
+                                  root-measure (when (and measure-ops (every? some? child-measure))
+                                                 (reduce (fn [acc cs]
+                                                           (measure/merge-measure measure-ops acc cs))
+                                                         (measure/identity-measure measure-ops)
+                                                         child-measure))]
                             ;; diff-buf: new root on growth — _bufEntries = 0 (no buffered diff; this
                             ;; node is always the root ⇒ always written; if later mutated in a transient
                             ;; batch the first deposit poisons it correctly). Mirrors JVM makeBranchFromChildren.
-                            (BTSet. (Branch. lvl (arrays/amap node/max-key roots) roots nil subtree-count root-measure (.-settings set) nil 0 (.-comparator set))
-                                    new-cnt
-                                    (.-comparator set)
-                                    (.-meta set)
-                                    UNINITIALIZED_HASH
-                                    (.-storage set)
-                                    nil
-                                    (.-settings set)))))))))))))
+                              (BTSet. (Branch. lvl (arrays/amap node/max-key roots) roots nil subtree-count root-measure (.-settings set) nil 0 (.-comparator set))
+                                      new-cnt
+                                      (.-comparator set)
+                                      (.-meta set)
+                                      UNINITIALIZED_HASH
+                                      (.-storage set)
+                                      nil
+                                      (.-settings set)))))))))))))
 
 (defn $replace
   ([^BTSet set old-key new-key]

--- a/src-clojure/org/replikativ/persistent_sorted_set/btset.cljs
+++ b/src-clojure/org/replikativ/persistent_sorted_set/btset.cljs
@@ -24,7 +24,12 @@
                (do
                  (when (and (nil? (.-root set)) (some? (.-address set)))
                    (assert (implements? storage/IStorage (.-storage set)))
-                   (set! (.-root set) (await (storage/restore (.-storage set) (.-address set) opts)))))
+                   (set! (.-root set) (await (storage/restore (.-storage set) (.-address set) opts)))
+                   ;; self-describing boundary: a restored node carries its split strategy; adopt
+                   ;; it so conj/disj use the right splitter even when restore opts omitted it.
+                   (let [nb (b/content-boundary (.-settings (.-root set)))]
+                     (when (and nb (not (b/content-boundary (.-settings set))))
+                       (set! (.-settings set) (assoc (.-settings set) :boundary nb))))))
                ;; diff-buf: seed the projection comparator at the root; branch/child propagates it
                ;; down as nodes materialize, so a leaf-parent can project buffered leaves with the
                ;; set's stable comparator. Idempotent; a Leaf root has no buffered children.
@@ -53,89 +58,121 @@
 ;; Parallel of the JVM PersistentSortedSet.growRoot + ANode.removeContent/mstMergeWith.
 ;; MST forces diff-buf off, so these build anchorless branches (no slots/addresses).
 
+(defn- free-addr [storage addr] (when (and storage addr) (storage/markFreed storage addr)) nil)
+
 (defn- mst-build-branch
-  "Build a level-`lvl` Branch from a seq of child nodes."
-  [lvl children-seq settings projcmp]
-  (let [carr          (arrays/into-array children-seq)
-        child-counts  (map node/subtree-count children-seq)
-        subtree-count (if (every? #(>= % 0) child-counts) (reduce + 0 child-counts) -1)
-        measure-ops   (:measure settings)
-        cmeas         (when measure-ops (map node/measure children-seq))
-        measure       (when (and measure-ops (every? some? cmeas))
-                        (reduce (fn [acc cs] (measure/merge-measure measure-ops acc cs))
-                                (measure/identity-measure measure-ops) cmeas))]
-    (Branch. lvl (arrays/amap node/max-key carr) carr nil subtree-count measure settings nil 0 projcmp)))
+  "Build a level-`lvl` Branch from a seq of child nodes. `addresses-seq` (optional) is the parallel
+   durable addresses to PRESERVE (nil ⇒ anchorless, all children re-stored)."
+  ([lvl children-seq settings projcmp] (mst-build-branch lvl children-seq settings projcmp nil))
+  ([lvl children-seq settings projcmp addresses-seq]
+   (let [carr          (arrays/into-array children-seq)
+         child-counts  (map node/subtree-count children-seq)
+         subtree-count (if (every? #(>= % 0) child-counts) (reduce + 0 child-counts) -1)
+         measure-ops   (:measure settings)
+         cmeas         (when measure-ops (map node/measure children-seq))
+         measure       (when (and measure-ops (every? some? cmeas))
+                         (reduce (fn [acc cs] (measure/merge-measure measure-ops acc cs))
+                                 (measure/identity-measure measure-ops) cmeas))]
+     (Branch. lvl (arrays/amap node/max-key carr) carr
+              (when addresses-seq (arrays/into-array addresses-seq))
+              subtree-count measure settings nil 0 projcmp))))
 
 (defn- mst-children
-  "Vector of a branch's (materialized) children. MST is storage-light: in-memory children are
-   populated directly. (Storage-backed MST remove — needing async restore — is a follow-up.)"
-  [^Branch node]
-  (let [ch (.-children node) n (arrays/alength (.-keys node))]
-    (mapv #(aget ch %) (range n))))
+  "Materialize a branch's children (storage-aware) → (async [children-vec addresses-vec]). Each
+   address is the child's durable address (nil if unstored), preserved on rebuild."
+  [^Branch node storage {:keys [sync?] :or {sync? true} :as opts}]
+  (async+sync sync?
+   (async
+    (let [n (arrays/alength (.-keys node))]
+      (loop [i 0 cs (transient []) as (transient [])]
+        (if (< i n)
+          (recur (inc i)
+                 (conj! cs (await (branch/child node storage i opts)))
+                 (conj! as (branch/address node i)))
+          [(persistent! cs) (persistent! as)]))))))
 
 (declare mst-merge-with mst-remove-content)
 
 (defn- mst-merge-with
   "Combine two same-level nodes whose separating (removed) boundary is gone. The junction —
    a's last child with b's first child — merges recursively ONLY when a's last child ended at
-   that removed boundary (its maxKey is no longer a boundary at its level). If a's last child
-   is still terminated by a LIVE boundary (e.g. a's deepest boundary leaf was dropped, leaving
-   a's tail a properly-terminated leaf), the two must NOT fuse — plain concatenation keeps the
-   live boundary. The inverse of add's promotion (≡ JVM ANode.mstMergeWith)."
-  [a b projcmp bd]
-  (if (instance? Leaf a)
-    ;; reached as a junction ⇒ a ended at the removed boundary (level 0) ⇒ concatenate
-    (let [settings    (.-settings a)
-          measure-ops (:measure settings)
-          lf          (Leaf. (arrays/aconcat (.-keys a) (.-keys b)) settings nil)]
-      (when measure-ops (node/try-compute-measure lf nil measure-ops {:sync? true}))
-      lf)
-    (let [a-ch (mst-children a)
-          b-ch (mst-children b)]
-      (if (>= (b/-key-level bd (node/max-key a)) (.-level a))
-        ;; a's last child is a live boundary ⇒ keep it; just concatenate the child lists.
-        (mst-build-branch (.-level a) (concat a-ch b-ch) (.-settings a) projcmp)
-        ;; a's last child ended at the removed boundary ⇒ merge the junction.
-        (let [junction (mst-merge-with (last a-ch) (first b-ch) projcmp bd)]
-          (mst-build-branch (.-level a) (concat (butlast a-ch) [junction] (rest b-ch))
-                            (.-settings a) projcmp))))))
+   that removed boundary. If a's last child is still terminated by a LIVE boundary, the two must
+   NOT fuse — plain concatenation keeps it. Storage-aware + address-preserving (≡ JVM
+   ANode.mstMergeWith). Returns (async node)."
+  [a b projcmp bd storage {:keys [sync?] :or {sync? true} :as opts}]
+  (async+sync sync?
+   (async
+    (if (instance? Leaf a)
+     ;; reached as a junction ⇒ a ended at the removed boundary (level 0) ⇒ concatenate
+     (let [settings    (.-settings a)
+           measure-ops (:measure settings)
+           lf          (Leaf. (arrays/aconcat (.-keys a) (.-keys b)) settings nil)]
+       (when measure-ops (node/try-compute-measure lf nil measure-ops {:sync? true}))
+       lf)
+     (let [[a-ch a-ad] (await (mst-children a storage opts))
+           [b-ch b-ad] (await (mst-children b storage opts))]
+       (if (>= (b/-key-level bd (node/max-key a)) (.-level a))
+         ;; a's last child is a live boundary ⇒ keep it; concatenate (all addresses preserved).
+         (mst-build-branch (.-level a) (concat a-ch b-ch) (.-settings a) projcmp (concat a-ad b-ad))
+         ;; a's last child ended at the removed boundary ⇒ merge the junction (consumed inputs freed).
+         (let [junction (await (mst-merge-with (last a-ch) (first b-ch) projcmp bd storage opts))]
+           (free-addr storage (last a-ad))
+           (free-addr storage (first b-ad))
+           (mst-build-branch (.-level a)
+                             (concat (butlast a-ch) [junction] (rest b-ch))
+                             (.-settings a) projcmp
+                             (concat (butlast a-ad) [nil] (rest b-ad))))))))))
 
 (defn- mst-remove-content
-  "MST remove without sibling-passing: returns the modified subtree (one node, possibly an
-   empty Leaf), or nil if key absent. A Branch merges two of its own children when the removed
-   key was a boundary at its level; the cross-parent case is handled by the grandparent.
-   Synchronous (≡ JVM ANode.removeContent)."
-  [node key cmp projcmp]
-  (if (instance? Leaf node)
-    (let [keys (.-keys node)
-          idx  (lookup-exact cmp keys key)]
-      (when (>= idx 0)
-        (let [settings    (.-settings node)
-              measure-ops (:measure settings)
-              lf          (Leaf. (splice keys idx (inc idx) (arrays/array)) settings nil)]
-          (when measure-ops (node/try-compute-measure lf nil measure-ops {:sync? true}))
-          lf)))
-    (let [keys (.-keys node)
-          n    (arrays/alength keys)
-          idx  (binary-search-l cmp keys (dec n) key)]
-      (if (== idx n)
-        nil
-        (let [children  (mst-children node)
-              new-child (mst-remove-content (nth children idx) key cmp projcmp)]
-          (if (nil? new-child)
-            nil
-            (let [bd          (b/content-boundary (.-settings node))
-                  lvl         (.-level node)
-                  empty-leaf? (and (instance? Leaf new-child) (== 0 (arrays/alength (.-keys new-child))))
-                  merge-right? (and (< idx (dec n)) (>= (b/-key-level bd key) lvl))
-                  new-children (cond
-                                 empty-leaf?  (concat (take idx children) (drop (inc idx) children))
-                                 merge-right? (let [merged (mst-merge-with new-child (nth children (inc idx)) projcmp bd)]
-                                                (concat (take idx children) [merged] (drop (+ idx 2) children)))
-                                 :else        (concat (take idx children) [new-child] (drop (inc idx) children)))]
-              (if (seq new-children)
-                (mst-build-branch lvl new-children (.-settings node) projcmp)
-                (Leaf. (arrays/array) (.-settings node) nil)))))))))
+  "MST remove without sibling-passing: returns (async <modified subtree, or empty Leaf>) or
+   (async nil) if key absent. Storage-aware + address-preserving (≡ JVM ANode.removeContent)."
+  [node storage key cmp projcmp {:keys [sync?] :or {sync? true} :as opts}]
+  (async+sync sync?
+   (async
+    (if (instance? Leaf node)
+     (let [keys (.-keys node)
+           idx  (lookup-exact cmp keys key)]
+       (when (>= idx 0)
+         (let [settings    (.-settings node)
+               measure-ops (:measure settings)
+               lf          (Leaf. (splice keys idx (inc idx) (arrays/array)) settings nil)]
+           (when measure-ops (node/try-compute-measure lf nil measure-ops {:sync? true}))
+           lf)))
+     (let [keys (.-keys node)
+           n    (arrays/alength keys)
+           idx  (binary-search-l cmp keys (dec n) key)]
+       (if (== idx n)
+         nil
+         (let [[children addrs] (await (mst-children node storage opts))
+               new-child        (await (mst-remove-content (nth children idx) storage key cmp projcmp opts))]
+           (if (nil? new-child)
+             nil
+             (let [bd          (b/content-boundary (.-settings node))
+                   lvl         (.-level node)
+                   settings    (.-settings node)
+                   empty-leaf? (and (instance? Leaf new-child) (== 0 (arrays/alength (.-keys new-child))))
+                   merge-right? (and (< idx (dec n)) (>= (b/-key-level bd key) lvl))]
+               (cond
+                 empty-leaf?
+                 (do (free-addr storage (nth addrs idx))
+                     (let [nc (concat (take idx children) (drop (inc idx) children))
+                           na (concat (take idx addrs) (drop (inc idx) addrs))]
+                       (if (seq nc) (mst-build-branch lvl nc settings projcmp na)
+                           (Leaf. (arrays/array) settings nil))))
+                 merge-right?
+                 (let [merged (await (mst-merge-with new-child (nth children (inc idx)) projcmp bd storage opts))]
+                   (free-addr storage (nth addrs idx))
+                   (free-addr storage (nth addrs (inc idx)))
+                   (mst-build-branch lvl
+                                     (concat (take idx children) [merged] (drop (+ idx 2) children))
+                                     settings projcmp
+                                     (concat (take idx addrs) [nil] (drop (+ idx 2) addrs))))
+                 :else
+                 (do (free-addr storage (nth addrs idx))
+                     (mst-build-branch lvl
+                                       (concat (take idx children) [new-child] (drop (inc idx) children))
+                                       settings projcmp
+                                       (concat (take idx addrs) [nil] (drop (inc idx) addrs))))))))))))))
 
 (defn- mst-grow-root
   "Promote sibling roots by boundary level until one remains (multi-level for high-level keys)."
@@ -283,8 +320,8 @@
                       bd   (b/content-boundary (.-settings set))]
                   (if bd
                     ;; split-seam (MST): sibling-free removeContent + single-child root collapse
-                    ;; (≡ JVM disjoin content branch). Synchronous (in-memory MST).
-                    (let [new-root (mst-remove-content root key cmp (.-comparator set))]
+                    ;; (≡ JVM disjoin content branch). Storage-aware (await child materialization).
+                    (let [new-root (await (mst-remove-content root (.-storage set) key cmp (.-comparator set) opts))]
                       (if (nil? new-root)
                         set
                         (do
@@ -293,7 +330,7 @@
                           (let [new-root (loop [r new-root]
                                            (if (and (instance? Branch r)
                                                     (== 1 (arrays/alength (.-keys r))))
-                                             (recur (aget (.-children r) 0))
+                                             (recur (await (branch/child r (.-storage set) 0 opts)))
                                              r))
                                 current-cnt (.-cnt set)
                                 new-cnt (if (neg? current-cnt) -1 (dec current-cnt))]
@@ -1582,7 +1619,7 @@
 
 #!------------------------------------------------------------------------------
 
-(deftype BTSet [^:mutable root cnt comparator meta ^:mutable _hash storage ^:mutable address settings]
+(deftype BTSet [^:mutable root cnt comparator meta ^:mutable _hash storage ^:mutable address ^:mutable settings]
   Object
   (toString [this] (pr-str* this))
 

--- a/src-clojure/org/replikativ/persistent_sorted_set/btset.cljs
+++ b/src-clojure/org/replikativ/persistent_sorted_set/btset.cljs
@@ -29,7 +29,11 @@
                    ;; it so conj/disj use the right splitter even when restore opts omitted it.
                    (let [nb (b/content-boundary (.-settings (.-root set)))]
                      (when (and nb (not (b/content-boundary (.-settings set))))
-                       (set! (.-settings set) (assoc (.-settings set) :boundary nb))))))
+                       ;; nb is content-defined ⇒ force diff-buf OFF too (mirrors the JVM root()
+                       ;; adoption via Settings.withBoundary). Otherwise a set restored with
+                       ;; :diff-buf-size > 0 would run MST + diff-buf together, breaking canonical
+                       ;; addressing. See doc/merkle-search-tree.md (Incompatibilities).
+                       (set! (.-settings set) (assoc (.-settings set) :boundary nb :diff-buf-size 0))))))
                ;; diff-buf: seed the projection comparator at the root; branch/child propagates it
                ;; down as nodes materialize, so a leaf-parent can project buffered leaves with the
                ;; set's stable comparator. Idempotent; a Leaf root has no buffered children.
@@ -273,38 +277,49 @@
   ([^BTSet set old-key new-key cmp {:keys [sync?] :or {sync? true} :as opts}]
    (async+sync sync?
                (async
-                (let [root  (await (-root set opts))
-                      nodes (await (node/$replace root (.-storage set) old-key new-key cmp opts))]
-                  (cond
-                    (nil? nodes) set
+                (let [bd (b/content-boundary (.-settings set))]
+                  (if (and bd (not= (b/-key-level bd old-key) (b/-key-level bd new-key)))
+                    ;; split-seam (MST): an in-place replace keeps the tree's boundary structure, which
+                    ;; is canonical ONLY when old-key and new-key rise to the same level. When a partial
+                    ;; comparator shifts the key hash across a level boundary, rebuild via disj+conj so
+                    ;; the tree re-splits/merges into the history-independent shape (count mode is
+                    ;; position-only ⇒ always in-place). See doc/merkle-search-tree.md.
+                    (let [root (await (-root set opts))]
+                      (if (await (node/$contains? root (.-storage set) old-key cmp opts))
+                        (await (conjoin (await (disjoin set old-key cmp opts)) new-key cmp opts))
+                        set))
+                    (let [root  (await (-root set opts))
+                          nodes (await (node/$replace root (.-storage set) old-key new-key cmp opts))]
+                      (cond
+                        (nil? nodes) set
 
-                    ;; In-place update (transient) — root modified, just clear address
-                    (= nodes :early-exit)
-                    (do
-                      (when (and (.-storage set) (.-address set))
-                        (storage/markFreed (.-storage set) (.-address set)))
-                      (BTSet. (.-root set)
-                              (.-cnt set)
-                              (.-comparator set)
-                              (.-meta set)
-                              UNINITIALIZED_HASH
-                              (.-storage set)
-                              nil
-                              (.-settings set)))
+                        ;; In-place update (transient) — root modified, just clear address
+                        (= nodes :early-exit)
+                        (do
+                          (when (and (.-storage set) (.-address set))
+                            (storage/markFreed (.-storage set) (.-address set)))
+                          (BTSet. (.-root set)
+                                  (.-cnt set)
+                                  (.-comparator set)
+                                  (.-meta set)
+                                  UNINITIALIZED_HASH
+                                  (.-storage set)
+                                  nil
+                                  (.-settings set)))
 
-                    ;; New root node (persistent or maxKey changed)
-                    :else
-                    (do
-                      (when (and (.-storage set) (.-address set))
-                        (storage/markFreed (.-storage set) (.-address set)))
-                      (BTSet. (arrays/aget nodes 0)
-                              (.-cnt set)
-                              (.-comparator set)
-                              (.-meta set)
-                              UNINITIALIZED_HASH
-                              (.-storage set)
-                              nil
-                              (.-settings set)))))))))
+                        ;; New root node (persistent or maxKey changed)
+                        :else
+                        (do
+                          (when (and (.-storage set) (.-address set))
+                            (storage/markFreed (.-storage set) (.-address set)))
+                          (BTSet. (arrays/aget nodes 0)
+                                  (.-cnt set)
+                                  (.-comparator set)
+                                  (.-meta set)
+                                  UNINITIALIZED_HASH
+                                  (.-storage set)
+                                  nil
+                                  (.-settings set)))))))))))
 
 (defn disjoin
   ([^BTSet set key]

--- a/src-clojure/org/replikativ/persistent_sorted_set/fressian.cljc
+++ b/src-clojure/org/replikativ/persistent_sorted_set/fressian.cljc
@@ -52,12 +52,14 @@
                                 :measure-ops nil :default-bf 512 :element-read-handlers {…}})
      (canonical-write-handlers {:element-write-handlers {…}})
    or a wire peer: pass `(registry-storage-resolver)`/`(registry-cmp-resolver)`/`(registry-measure-resolver)`."
+  #?(:clj (:require [org.replikativ.persistent-sorted-set.impl.boundary :as bnd]))
   #?(:cljs (:require [fress.api :as fress]
                      [org.replikativ.persistent-sorted-set.impl.node :as node]
+                     [org.replikativ.persistent-sorted-set.impl.boundary :as bnd]
                      [org.replikativ.persistent-sorted-set.leaf :refer [Leaf]]
                      [org.replikativ.persistent-sorted-set.branch :refer [Branch] :as branch]
                      [org.replikativ.persistent-sorted-set.btset :refer [BTSet]]))
-  #?(:clj (:import [org.replikativ.persistent_sorted_set ANode Leaf Branch Settings Slot IMeasure RefType
+  #?(:clj (:import [org.replikativ.persistent_sorted_set ANode Leaf Branch Settings Slot IMeasure IBoundary RefType
                     PersistentSortedSet]
                    [org.fressian.handlers WriteHandler ReadHandler]
                    [java.util List])))
@@ -80,16 +82,20 @@
           (case kw :strong RefType/STRONG :soft RefType/SOFT :weak RefType/WEAK nil)))
 
 #?(:clj
-   (defn- settings-for ^Settings [bf dbs ^IMeasure measure ref-type]
+   (defn- settings-for ^Settings [bf dbs ^IMeasure measure ref-type bdesc]
      ;; ref-type nil ⇒ Settings normalizes to SOFT. `measure` is the IMeasure OPS the consumer
      ;; supplied (never serialized); leaf-processor stays nil — it's the operating root's, threaded.
-     (Settings. (int bf) (kw->ref-type ref-type) measure nil (int dbs)))
+     ;; bdesc (a serialized boundary descriptor, nil for count) is resolved INTERNALLY — the
+     ;; consumer never supplies a resolver; the strategy round-trips from the blob alone.
+     (let [s (Settings. (int bf) (kw->ref-type ref-type) measure nil (int dbs))]
+       (if bdesc (.withBoundary s ^IBoundary (bnd/resolve-boundary bdesc)) s)))
    :cljs
-   (defn- settings-for [bf dbs measure ref-type]
+   (defn- settings-for [bf dbs measure ref-type bdesc]
      ;; cljs has no soft/weak refs, so ref-type is inert here — but CARRY it so it round-trips
      ;; losslessly through a cljs relay (deserialize → re-serialize) back to a JVM reader.
      (cond-> {:branching-factor bf :diff-buf-size dbs :measure measure}
-       ref-type (assoc :ref-type ref-type))))
+       ref-type (assoc :ref-type ref-type)
+       bdesc    (assoc :boundary (bnd/resolve-boundary bdesc)))))
 
 (defn- node-config
   "A node's SERIALIZABLE settings — branching-factor + diff-buf-size + (non-default) ref-type. These
@@ -97,12 +103,16 @@
    unchanged. ref-type is omitted when SOFT (the default), so common-case blobs are byte-unchanged."
   [node]
   #?(:clj  (let [^Settings s (.-_settings ^ANode node)
-                 rt (.refType s)]
+                 rt (.refType s)
+                 bdesc (.descriptor (.boundary s))]   ; nil for count, {:type :mst :lzpl n} for MST
              (cond-> {:branching-factor (.branchingFactor s) :diff-buf-size (.diffBufSize s)}
-               (and rt (not= rt RefType/SOFT)) (assoc :ref-type (ref-type->kw rt))))
-     :cljs (let [s (.-settings node)]
+               (and rt (not= rt RefType/SOFT)) (assoc :ref-type (ref-type->kw rt))
+               bdesc (assoc :boundary bdesc)))
+     :cljs (let [s (.-settings node)
+                 bdesc (when-let [bd (:boundary s)] (bnd/-descriptor bd))]
              (cond-> {:branching-factor (:branching-factor s) :diff-buf-size (:diff-buf-size s)}
-               (:ref-type s) (assoc :ref-type (:ref-type s))))))
+               (:ref-type s) (assoc :ref-type (:ref-type s))
+               bdesc (assoc :boundary bdesc)))))
 
 ;; ---------------------------------------------------------------------------
 ;; node->map — the CONTENT projection (for content-addressing). Branching-factor/diff-buf are
@@ -187,20 +197,20 @@
    blob's serialized ref-type (default: use the blob, falling back to SOFT).
    Returns {tag handler}. Comparator-free (the comparator lives on the root)."
   [{:keys [measure-ops default-bf ref-type] :or {default-bf 0}}]
-  (let [mk-settings (memoize (fn [bf dbs rt] (settings-for bf dbs measure-ops rt)))]
+  (let [mk-settings (memoize (fn [bf dbs rt bdesc] (settings-for bf dbs measure-ops rt bdesc)))]
     #?(:clj
        {leaf-tag
         (reify ReadHandler
           (read [_ rdr _tag _n]
-            (let [{:keys [keys measure branching-factor diff-buf-size] blob-rt :ref-type} (.readObject rdr)
-                  l (Leaf. ^List keys (mk-settings (or branching-factor default-bf) (or diff-buf-size 0) (or ref-type blob-rt)))]
+            (let [{:keys [keys measure branching-factor diff-buf-size] blob-rt :ref-type blob-bdry :boundary} (.readObject rdr)
+                  l (Leaf. ^List keys (mk-settings (or branching-factor default-bf) (or diff-buf-size 0) (or ref-type blob-rt) blob-bdry))]
               (when (some? measure) (set! (.-_measure ^ANode l) measure))
               l)))
         branch-tag
         (reify ReadHandler
           (read [_ rdr _tag _n]
-            (let [{:keys [level keys addresses subtree-count measure slots branching-factor diff-buf-size] blob-rt :ref-type} (.readObject rdr)
-                  b (Branch. (int level) ^List keys ^List addresses (mk-settings (or branching-factor default-bf) (or diff-buf-size 0) (or ref-type blob-rt)))]
+            (let [{:keys [level keys addresses subtree-count measure slots branching-factor diff-buf-size] blob-rt :ref-type blob-bdry :boundary} (.readObject rdr)
+                  b (Branch. (int level) ^List keys ^List addresses (mk-settings (or branching-factor default-bf) (or diff-buf-size 0) (or ref-type blob-rt) blob-bdry))]
               (set! (.-_subtreeCount b) (long (or subtree-count -1)))
               (when (some? measure) (set! (.-_measure ^ANode b) measure))
               (when slots (attach-slots! b addresses slots))
@@ -208,17 +218,17 @@
        :cljs
        {leaf-tag
         (fn [rdr _tag _n]
-          (let [{:keys [keys measure branching-factor diff-buf-size] blob-rt :ref-type} (fress/read-object rdr)]
-            (Leaf. (to-array keys) (mk-settings (or branching-factor default-bf) (or diff-buf-size 0) (or ref-type blob-rt)) measure)))
+          (let [{:keys [keys measure branching-factor diff-buf-size] blob-rt :ref-type blob-bdry :boundary} (fress/read-object rdr)]
+            (Leaf. (to-array keys) (mk-settings (or branching-factor default-bf) (or diff-buf-size 0) (or ref-type blob-rt) blob-bdry) measure)))
         branch-tag
         (fn [rdr _tag _n]
-          (let [{:keys [level keys addresses subtree-count measure slots branching-factor diff-buf-size] blob-rt :ref-type} (fress/read-object rdr)
+          (let [{:keys [level keys addresses subtree-count measure slots branching-factor diff-buf-size] blob-rt :ref-type blob-bdry :boundary} (fress/read-object rdr)
                 node (branch/from-map {:level         level
                                        :keys          (to-array keys)
                                        :addresses     (to-array addresses)
                                        :subtree-count subtree-count
                                        :measure       measure
-                                       :settings      (mk-settings (or branching-factor default-bf) (or diff-buf-size 0) (or ref-type blob-rt))})]
+                                       :settings      (mk-settings (or branching-factor default-bf) (or diff-buf-size 0) (or ref-type blob-rt) blob-bdry)})]
             (when slots (attach-slots! node addresses slots))
             node))})))
 
@@ -268,26 +278,30 @@
          (when (nil? (.-_address ^PersistentSortedSet pset))
            (throw (ex-info "PSS root must be flushed before serialization" {:type :must-be-flushed})))
          (let [^Settings s (.-_settings ^PersistentSortedSet pset)
-               rt (.refType s)]
+               rt (.refType s)
+               bdesc (.descriptor (.boundary s))]
            (.writeTag w set-tag 1)
            (.writeObject w (cond-> {:meta             (meta pset)
                                     :address          (.-_address ^PersistentSortedSet pset)
                                     :count            (count pset)
                                     :branching-factor (.branchingFactor s)
                                     :diff-buf-size    (.diffBufSize s)}
-                             (and rt (not= rt RefType/SOFT)) (assoc :ref-type (ref-type->kw rt)))))))
+                             (and rt (not= rt RefType/SOFT)) (assoc :ref-type (ref-type->kw rt))
+                             bdesc (assoc :boundary bdesc))))))
      :cljs
      (fn [w pset]
        (when (nil? (.-address pset))
          (throw (ex-info "PSS root must be flushed before serialization" {:type :must-be-flushed})))
-       (let [s (.-settings pset)]
+       (let [s (.-settings pset)
+             bdesc (when-let [bd (:boundary s)] (bnd/-descriptor bd))]
          (fress/write-tag w set-tag 1)
          (fress/write-object w (cond-> {:meta             (meta pset)
                                         :address          (.-address pset)
                                         :count            (count pset)
                                         :branching-factor (:branching-factor s)
                                         :diff-buf-size    (:diff-buf-size s)}
-                                 (:ref-type s) (assoc :ref-type (:ref-type s))))))))
+                                 (:ref-type s) (assoc :ref-type (:ref-type s))
+                                 bdesc (assoc :boundary bdesc)))))))
 
 (def root-write-handlers
   "Pre-keyed root write handler, shaped like `write-handlers` so a cljc consumer merges it WITHOUT
@@ -311,14 +325,14 @@
    #?(:clj
       (reify ReadHandler
         (read [_ rdr _tag _n]
-          (let [{:keys [meta address count branching-factor diff-buf-size] blob-rt :ref-type} (.readObject rdr)
-                settings (settings-for (or branching-factor default-bf) (or diff-buf-size 0) (resolve-measure meta) (or ref-type blob-rt))]
+          (let [{:keys [meta address count branching-factor diff-buf-size] blob-rt :ref-type blob-bdry :boundary} (.readObject rdr)
+                settings (settings-for (or branching-factor default-bf) (or diff-buf-size 0) (resolve-measure meta) (or ref-type blob-rt) blob-bdry)]
             (PersistentSortedSet. meta (resolve-cmp meta) address (resolve-storage meta)
                                   nil (int count) settings 0))))
       :cljs
       (fn [rdr _tag _n]
-        (let [{:keys [meta address count branching-factor diff-buf-size] blob-rt :ref-type} (fress/read-object rdr)
-              settings (settings-for (or branching-factor default-bf) (or diff-buf-size 0) (resolve-measure meta) (or ref-type blob-rt))]
+        (let [{:keys [meta address count branching-factor diff-buf-size] blob-rt :ref-type blob-bdry :boundary} (fress/read-object rdr)
+              settings (settings-for (or branching-factor default-bf) (or diff-buf-size 0) (resolve-measure meta) (or ref-type blob-rt) blob-bdry)]
           ;; BTSet deftype: [root cnt comparator meta _hash storage address settings]
           (BTSet. nil count (resolve-cmp meta) meta nil (resolve-storage meta) address settings))))))
 

--- a/src-clojure/org/replikativ/persistent_sorted_set/impl/boundary.cljc
+++ b/src-clojure/org/replikativ/persistent_sorted_set/impl/boundary.cljc
@@ -12,10 +12,10 @@
 #?(:cljs
    (defprotocol PBoundary
      "CLJS parallel of the Java IBoundary seam (MST only — count stays inline)."
-     (-overflows? [_ run len level]
-       "MST: does some key at index <len-1 rise to level+1 (a content boundary before the end)?")
-     (-split-lengths [_ run len level]
-       "MST: vector of successive node lengths (summing to len) — cut after each boundary key.")
+     (-split-on-insert [_ run len ins level]
+       "MST: O(1) split decision after a single key was inserted at `ins` (run[ins] is the new
+        key). Returns [len-a len-b] if it must split, else nil. Only the inserted key — or the
+        displaced old max when appended — can be a new boundary.")
      (-key-level [_ key]
        "The level a key rises to (0 ⇒ leaf-only).")
      (-content-defined? [_] "true for MST.")))

--- a/src-clojure/org/replikativ/persistent_sorted_set/impl/boundary.cljc
+++ b/src-clojure/org/replikativ/persistent_sorted_set/impl/boundary.cljc
@@ -18,7 +18,8 @@
         displaced old max when appended — can be a new boundary.")
      (-key-level [_ key]
        "The level a key rises to (0 ⇒ leaf-only).")
-     (-content-defined? [_] "true for MST.")))
+     (-content-defined? [_] "true for MST.")
+     (-descriptor [_] "Serializable descriptor {:type … …} for self-describing restore.")))
 
 #?(:cljs
    (defn content-boundary
@@ -27,3 +28,25 @@
      [settings]
      (when-let [b (:boundary settings)]
        (when (-content-defined? b) b))))
+
+;; ---- internal descriptor → boundary resolution (NO consumer interaction) ------------------
+;; The descriptor→strategy mapping lives in the optional `boundary` ns (which carries hasch). We
+;; resolve it INTERNALLY so fressian restore reconstructs the strategy from the serialized data
+;; alone: JVM lazy-loads that ns on demand (count blobs never trigger it ⇒ never load hasch);
+;; cljs has no dynamic require, so `boundary` registers its resolver here when it loads (you
+;; always load `boundary` to create an MST set in the first place).
+
+#?(:cljs (defonce ^:private mst-resolver (atom nil)))
+#?(:cljs (defn register-resolver! [f] (reset! mst-resolver f)))
+
+(defn resolve-boundary
+  "Reconstruct an IBoundary/PBoundary from its serialized descriptor (e.g. {:type :mst :lzpl 6}),
+   or nil for none. Internal to PSS — never supplied by the consumer."
+  [descriptor]
+  (when descriptor
+    #?(:clj  ((requiring-resolve 'org.replikativ.persistent-sorted-set.boundary/boundary-from-descriptor)
+              descriptor)
+       :cljs (if-let [f @mst-resolver]
+               (f descriptor)
+               (throw (ex-info "node carries a content-defined boundary but the boundary ns isn't loaded — (require 'org.replikativ.persistent-sorted-set.boundary)"
+                               {:descriptor descriptor}))))))

--- a/src-clojure/org/replikativ/persistent_sorted_set/impl/boundary.cljc
+++ b/src-clojure/org/replikativ/persistent_sorted_set/impl/boundary.cljc
@@ -1,0 +1,29 @@
+(ns org.replikativ.persistent-sorted-set.impl.boundary
+  "Lightweight content-boundary protocol for the CLJS node code. Holds NO hasch dependency so
+   the core cljs bundle stays hash-free in the default (count) mode — the MST boundary (which
+   needs hasch) lives in the separate optional `boundary` ns and implements this protocol.
+
+   The cljs count split differs in an irrelevant detail from the JVM count split (which side an
+   inserted key lands on a midpoint tie), so — unlike the JVM, which routes count through the
+   seam byte-identically — the cljs side keeps its existing inline count path untouched and
+   only *gates* the MST path on `content-boundary`. MST itself is unambiguous (the cut is at the
+   boundary key's position), so it is identical across platforms. See SPLIT_SEAM_DESIGN.md.")
+
+#?(:cljs
+   (defprotocol PBoundary
+     "CLJS parallel of the Java IBoundary seam (MST only — count stays inline)."
+     (-overflows? [_ run len level]
+       "MST: does some key at index <len-1 rise to level+1 (a content boundary before the end)?")
+     (-split-lengths [_ run len level]
+       "MST: vector of successive node lengths (summing to len) — cut after each boundary key.")
+     (-key-level [_ key]
+       "The level a key rises to (0 ⇒ leaf-only).")
+     (-content-defined? [_] "true for MST.")))
+
+#?(:cljs
+   (defn content-boundary
+     "The settings' boundary iff it is content-defined (MST), else nil ⇒ use the inline count
+      path. The cljs gate that mirrors the JVM `boundary().contentDefined()` branch."
+     [settings]
+     (when-let [b (:boundary settings)]
+       (when (-content-defined? b) b))))

--- a/src-clojure/org/replikativ/persistent_sorted_set/leaf.cljs
+++ b/src-clojure/org/replikativ/persistent_sorted_set/leaf.cljs
@@ -6,6 +6,7 @@
             [org.replikativ.persistent-sorted-set.impl.node :as node :refer [INode]]
             [org.replikativ.persistent-sorted-set.impl.measure :as measure]
             [org.replikativ.persistent-sorted-set.impl.storage :as storage]
+            [org.replikativ.persistent-sorted-set.impl.boundary :as b]
             [org.replikativ.persistent-sorted-set.util :as util]))
 
 (deftype Leaf [keys settings ^:mutable _measure]
@@ -50,11 +51,32 @@
   (add [this storage key cmp {:keys [sync?] :or {sync? true}}]
     (let [branching-factor (:branching-factor settings)
           measure-ops (:measure settings)
+          bd               (b/content-boundary settings)
           idx              (util/binary-search-l cmp keys (dec (arrays/alength keys)) key)
           keys-l           (arrays/alength keys)
           result           (cond
                              (and (< idx keys-l) (== 0 (cmp key (arrays/aget keys idx))))
                              nil
+
+                             ;; split-seam (MST): build the full run, then cut at boundary keys.
+                             ;; Identical to the JVM Leaf.add seam path; key-level is shared cljc.
+                             bd
+                             (let [all-keys (util/splice keys idx idx (arrays/array key))
+                                   total    (arrays/alength all-keys)]
+                               (if (b/-overflows? bd all-keys total 0)
+                                 (let [lens (b/-split-lengths bd all-keys total 0)]
+                                   (loop [out (transient []), pos 0, ls lens]
+                                     (if (seq ls)
+                                       (let [l  (first ls)
+                                             lf (Leaf. (.slice all-keys pos (+ pos l)) settings nil)]
+                                         (when (and measure-ops _measure)
+                                           (node/try-compute-measure lf nil measure-ops {:sync? true}))
+                                         (recur (conj! out lf) (+ pos l) (next ls)))
+                                       (arrays/into-array (persistent! out)))))
+                                 (let [lf (Leaf. all-keys settings nil)]
+                                   (when (and measure-ops _measure)
+                                     (node/try-compute-measure lf nil measure-ops {:sync? true}))
+                                   (arrays/array lf))))
 
                              (== keys-l branching-factor)
                              (let [middle (arrays/half (inc keys-l))

--- a/src-clojure/org/replikativ/persistent_sorted_set/leaf.cljs
+++ b/src-clojure/org/replikativ/persistent_sorted_set/leaf.cljs
@@ -62,21 +62,21 @@
                              ;; Identical to the JVM Leaf.add seam path; key-level is shared cljc.
                              bd
                              (let [all-keys (util/splice keys idx idx (arrays/array key))
-                                   total    (arrays/alength all-keys)]
-                               (if (b/-overflows? bd all-keys total 0)
-                                 (let [lens (b/-split-lengths bd all-keys total 0)]
-                                   (loop [out (transient []), pos 0, ls lens]
-                                     (if (seq ls)
-                                       (let [l  (first ls)
-                                             lf (Leaf. (.slice all-keys pos (+ pos l)) settings nil)]
-                                         (when (and measure-ops _measure)
-                                           (node/try-compute-measure lf nil measure-ops {:sync? true}))
-                                         (recur (conj! out lf) (+ pos l) (next ls)))
-                                       (arrays/into-array (persistent! out)))))
+                                   total    (arrays/alength all-keys)
+                                   lens     (b/-split-on-insert bd all-keys total idx 0)]  ; idx = insert pos
+                               (if (nil? lens)
                                  (let [lf (Leaf. all-keys settings nil)]
                                    (when (and measure-ops _measure)
                                      (node/try-compute-measure lf nil measure-ops {:sync? true}))
-                                   (arrays/array lf))))
+                                   (arrays/array lf))
+                                 (loop [out (transient []), pos 0, ls lens]
+                                   (if (seq ls)
+                                     (let [l  (first ls)
+                                           lf (Leaf. (.slice all-keys pos (+ pos l)) settings nil)]
+                                       (when (and measure-ops _measure)
+                                         (node/try-compute-measure lf nil measure-ops {:sync? true}))
+                                       (recur (conj! out lf) (+ pos l) (next ls)))
+                                     (arrays/into-array (persistent! out))))))
 
                              (== keys-l branching-factor)
                              (let [middle (arrays/half (inc keys-l))

--- a/src-java/org/replikativ/persistent_sorted_set/ANode.java
+++ b/src-java/org/replikativ/persistent_sorted_set/ANode.java
@@ -207,9 +207,14 @@ public abstract class ANode<Key, Address> {
   public abstract void toString(StringBuilder sb, Address address, String indent);
 
   protected static int newLen(int len, Settings settings) {
-    if (settings.editable())
-        return Math.min(settings.branchingFactor(), len + settings.expandLen());
-    else
+    if (settings.editable()) {
+        int cap = len + settings.expandLen();
+        // split-seam: under a content-defined (MST) boundary a node's size is geometric and
+        // can exceed branchingFactor, so the editable array MUST hold the full len — capping
+        // at bf overflows large leaves (e.g. a 134-key leaf into a 64-slot array). Count keeps
+        // the historical bf cap (its nodes never exceed branchingFactor).
+        return settings.boundary().contentDefined() ? cap : Math.min(settings.branchingFactor(), cap);
+    } else
         return len;
   }
 

--- a/src-java/org/replikativ/persistent_sorted_set/ANode.java
+++ b/src-java/org/replikativ/persistent_sorted_set/ANode.java
@@ -180,6 +180,18 @@ public abstract class ANode<Key, Address> {
   public abstract ANode[] add(IStorage storage, Key key, Comparator<Key> cmp, Settings settings);
   public abstract ANode[] remove(IStorage storage, Key key, ANode left, ANode right, Comparator<Key> cmp, Settings settings);
 
+  // split-seam (MST/content mode): remove without sibling-passing. Returns the modified
+  // subtree (one node, possibly an empty Leaf), or null if the key was not present. Merges
+  // are driven by keyLevel (a Branch merges two of its own children when the removed key was
+  // a boundary at its level), so the cross-parent case is handled by the grandparent's merge.
+  // See .internal/SPLIT_SEAM_DESIGN.md. Only invoked when settings.boundary().contentDefined().
+  public abstract ANode removeContent(IStorage storage, Key key, Comparator<Key> cmp, Settings settings);
+
+  // MST merge: concatenate this node with its right neighbour (same level), recursively
+  // merging the junction (this.lastChild with right.firstChild) — the inverse of add's
+  // multi-level promotion. Both nodes are the same concrete type and level.
+  public abstract ANode mstMergeWith(ANode right, IStorage storage, Settings settings);
+
   /**
    * Replace an existing key with a new key at the same position.
    * The comparator must return 0 for both oldKey and newKey (same logical position).

--- a/src-java/org/replikativ/persistent_sorted_set/Branch.java
+++ b/src-java/org/replikativ/persistent_sorted_set/Branch.java
@@ -1200,7 +1200,15 @@ public class Branch<Key, Address> extends ANode<Key, Address> implements ISubtre
     // Child was replaced (nodes.length == 1)
     ANode<Key, Address> newChild = nodes[0];
     Key newMaxKey = newChild.maxKey();
-    boolean maxKeyChanged = (idx == _len - 1) && (0 != cmp.compare(newMaxKey, _keys[idx]));
+    // Whether to propagate up (rebuild parent) vs EARLY_EXIT a transient. Count mode is
+    // routing-only (by cmp), so the rightmost child's comparator-position change is the only
+    // thing a parent cares about. MST mode content-addresses the separator VALUE, so ANY value
+    // change must propagate so every separator up the spine stays canonical (mirrors the cljs
+    // Branch.$replace value-based test). _keys[idx] is still the OLD separator here (overwritten
+    // below). See doc/merkle-search-tree.md.
+    boolean maxKeyChanged = settings.boundary().contentDefined()
+      ? !java.util.Objects.equals(newMaxKey, _keys[idx])
+      : (idx == _len - 1) && (0 != cmp.compare(newMaxKey, _keys[idx]));
     IMeasure measureOps = settings.measure();
 
     // Transient: can modify in place

--- a/src-java/org/replikativ/persistent_sorted_set/Branch.java
+++ b/src-java/org/replikativ/persistent_sorted_set/Branch.java
@@ -1078,27 +1078,40 @@ public class Branch<Key, Address> extends ANode<Key, Address> implements ISubtre
     // iff keyLevel(key) >= this branch's level. Then those two children merge.
     boolean mergeRight = idx < _len - 1 && boundary.keyLevel(key, settings) >= _level;
 
+    // Preserve UNCHANGED children's durable addresses (so store() doesn't re-serialize whole
+    // subtrees on a remove); the changed/merged child gets a null address (re-stored), and the
+    // dropped/consumed old children are markFreed (mirrors the count remove's GC). _addresses
+    // null ⇒ in-memory, keep it null.
+    boolean hasAddr = _addresses != null;
     Object[] newChildren;
+    Address[] newAddresses = null;
     if (newChild instanceof Leaf && newChild._len == 0) {
       // Child's whole subtree is gone (it collapsed to an empty Leaf — note its level no
       // longer matches its siblings, so it can never participate in a merge): drop it. This
       // subsumes the mergeRight case, since merging an empty node with its sibling yields
       // exactly that sibling.
       newChildren = new Object[_len - 1];
-      for (int i = 0; i < idx; i++)        newChildren[i] = child(storage, i);
-      for (int i = idx + 1; i < _len; i++) newChildren[i - 1] = child(storage, i);
+      if (hasAddr) newAddresses = (Address[]) new Object[_len - 1];
+      for (int i = 0; i < idx; i++)        { newChildren[i] = child(storage, i);     if (hasAddr) newAddresses[i] = address(i); }
+      for (int i = idx + 1; i < _len; i++) { newChildren[i - 1] = child(storage, i);  if (hasAddr) newAddresses[i - 1] = address(i); }
+      freeDroppedChild(storage, idx);
     } else if (mergeRight) {
       // merge newChild with the right sibling child (junction merges recursively down).
       ANode merged = newChild.mstMergeWith(child(storage, idx + 1), storage, settings);
       newChildren = new Object[_len - 1];
-      for (int i = 0; i < idx; i++)            newChildren[i] = child(storage, i);
-      newChildren[idx] = merged;
-      for (int i = idx + 2; i < _len; i++)     newChildren[i - 1] = child(storage, i);
+      if (hasAddr) newAddresses = (Address[]) new Object[_len - 1];
+      for (int i = 0; i < idx; i++)            { newChildren[i] = child(storage, i);     if (hasAddr) newAddresses[i] = address(i); }
+      newChildren[idx] = merged;                                      // merged is new ⇒ null address
+      for (int i = idx + 2; i < _len; i++)     { newChildren[i - 1] = child(storage, i);  if (hasAddr) newAddresses[i - 1] = address(i); }
+      freeDroppedChild(storage, idx);
+      freeDroppedChild(storage, idx + 1);                             // both consumed into the merge
     } else {
       // no boundary removed at this level: just replace child idx
       newChildren = new Object[_len];
+      if (hasAddr) { newAddresses = (Address[]) new Object[_len]; System.arraycopy(_addresses, 0, newAddresses, 0, _len); newAddresses[idx] = null; }
       for (int i = 0; i < _len; i++) newChildren[i] = child(storage, i);
       newChildren[idx] = newChild;
+      freeDroppedChild(storage, idx);
     }
 
     int n = newChildren.length;
@@ -1111,7 +1124,7 @@ public class Branch<Key, Address> extends ANode<Key, Address> implements ISubtre
     for (int i = 0; i < n; i++) keys[i] = ((ANode<Key, Address>) newChildren[i]).maxKey();
     long count = tryComputeSubtreeCountFromChildren(newChildren, n, storage);
     Object measure = tryComputeMeasureFromChildren(newChildren, n, storage, measureOps);
-    return new Branch(_level, n, keys, null, newChildren, count, measure, _projCmp, settings);
+    return new Branch(_level, n, keys, newAddresses, newChildren, count, measure, _projCmp, settings);
   }
 
   @Override
@@ -1120,7 +1133,9 @@ public class Branch<Key, Address> extends ANode<Key, Address> implements ISubtre
     IBoundary boundary = settings.boundary();
     IMeasure measureOps = settings.measure();
 
+    boolean hasAddr = _addresses != null || r._addresses != null;
     Object[] children;
+    Address[] addrs = null;
     int n;
     // The junction — this branch's last child with right's first child — fuses ONLY when this
     // branch's last child ended at the *removed* boundary (its maxKey is no longer a boundary
@@ -1131,22 +1146,27 @@ public class Branch<Key, Address> extends ANode<Key, Address> implements ISubtre
     if (boundary.keyLevel(maxKey(), settings) >= _level) {
       n = _len + r._len;
       children = new Object[n];
-      for (int i = 0; i < _len; i++)   children[i] = child(storage, i);
-      for (int i = 0; i < r._len; i++) children[_len + i] = r.child(storage, i);
+      if (hasAddr) addrs = (Address[]) new Object[n];
+      for (int i = 0; i < _len; i++)   { children[i] = child(storage, i);          if (hasAddr) addrs[i] = address(i); }
+      for (int i = 0; i < r._len; i++) { children[_len + i] = r.child(storage, i);  if (hasAddr) addrs[_len + i] = (Address) r.address(i); }
     } else {
       ANode junction = child(storage, _len - 1).mstMergeWith(r.child(storage, 0), storage, settings);
       n = _len + r._len - 1;
       children = new Object[n];
-      for (int i = 0; i < _len - 1; i++)  children[i] = child(storage, i);
-      children[_len - 1] = junction;
-      for (int i = 1; i < r._len; i++)    children[_len - 1 + i] = r.child(storage, i);
+      if (hasAddr) addrs = (Address[]) new Object[n];
+      for (int i = 0; i < _len - 1; i++)  { children[i] = child(storage, i);              if (hasAddr) addrs[i] = address(i); }
+      children[_len - 1] = junction;                                    // junction is new ⇒ null address
+      for (int i = 1; i < r._len; i++)    { children[_len - 1 + i] = r.child(storage, i);  if (hasAddr) addrs[_len - 1 + i] = (Address) r.address(i); }
+      // this's last child and r's first child were consumed into the junction
+      freeDroppedChild(storage, _len - 1);
+      if (storage != null && r.address(0) != null) storage.markFreed((Address) r.address(0));
     }
 
     Key[] keys = (Key[]) new Object[n];
     for (int i = 0; i < n; i++) keys[i] = ((ANode<Key, Address>) children[i]).maxKey();
     long count = tryComputeSubtreeCountFromChildren(children, n, storage);
     Object measure = tryComputeMeasureFromChildren(children, n, storage, measureOps);
-    return new Branch(_level, n, keys, null, children, count, measure, _projCmp, settings);
+    return new Branch(_level, n, keys, addrs, children, count, measure, _projCmp, settings);
   }
 
   @Override

--- a/src-java/org/replikativ/persistent_sorted_set/Branch.java
+++ b/src-java/org/replikativ/persistent_sorted_set/Branch.java
@@ -572,12 +572,12 @@ public class Branch<Key, Address> extends ANode<Key, Address> implements ISubtre
     }
 
     // split-seam: boundary policy decides overflow + cut. Count ⇒ newLen>bf, midpoint
-    // (byte-identical). MST ⇒ a promoted separator rises to level+1 (cut there). An
-    // incremental insert moves one key ⇒ at most one new boundary per level ⇒ ≤2-way.
-    IBoundary boundary = settings.boundary();
+    // (byte-identical). MST ⇒ O(1): the one promoted separator at `ins` (the split child's new
+    // max) is the only possible new boundary; cut there if it rises to level+1. null ⇒ absorb.
+    int[] lengths = settings.boundary().splitOnInsert(allKeys, newLen, ins, _level, settings);
 
     // Absorb: fits in single branch
-    if (!boundary.overflows(allKeys, newLen, _level, settings)) {
+    if (lengths == null) {
       // Use delta formula: exact and O(1), avoids scanning all children
       long count = (_subtreeCount >= 0 && oldChildCount >= 0 && newChildrenCount >= 0)
           ? _subtreeCount - oldChildCount + newChildrenCount : -1;
@@ -592,7 +592,7 @@ public class Branch<Key, Address> extends ANode<Key, Address> implements ISubtre
     }
 
     // Split into two branches (incremental ⇒ ≤2-way; lengths[0] is the first cut)
-    int half1 = boundary.splitLengths(allKeys, newLen, _level, settings)[0], half2 = newLen - half1;
+    int half1 = lengths[0], half2 = newLen - half1;
 
     Key[] keys1 = Arrays.copyOfRange(allKeys, 0, half1);
     Key[] keys2 = Arrays.copyOfRange(allKeys, half1, newLen);

--- a/src-java/org/replikativ/persistent_sorted_set/Branch.java
+++ b/src-java/org/replikativ/persistent_sorted_set/Branch.java
@@ -571,8 +571,13 @@ public class Branch<Key, Address> extends ANode<Key, Address> implements ISubtre
       as.copyAll(_addresses, ins + 1, _len);
     }
 
+    // split-seam: boundary policy decides overflow + cut. Count ⇒ newLen>bf, midpoint
+    // (byte-identical). MST ⇒ a promoted separator rises to level+1 (cut there). An
+    // incremental insert moves one key ⇒ at most one new boundary per level ⇒ ≤2-way.
+    IBoundary boundary = settings.boundary();
+
     // Absorb: fits in single branch
-    if (newLen <= settings.branchingFactor()) {
+    if (!boundary.overflows(allKeys, newLen, _level, settings)) {
       // Use delta formula: exact and O(1), avoids scanning all children
       long count = (_subtreeCount >= 0 && oldChildCount >= 0 && newChildrenCount >= 0)
           ? _subtreeCount - oldChildCount + newChildrenCount : -1;
@@ -586,8 +591,8 @@ public class Branch<Key, Address> extends ANode<Key, Address> implements ISubtre
       return new ANode[]{ nb };
     }
 
-    // Split into two branches
-    int half1 = newLen >>> 1, half2 = newLen - half1;
+    // Split into two branches (incremental ⇒ ≤2-way; lengths[0] is the first cut)
+    int half1 = boundary.splitLengths(allKeys, newLen, _level, settings)[0], half2 = newLen - half1;
 
     Key[] keys1 = Arrays.copyOfRange(allKeys, 0, half1);
     Key[] keys2 = Arrays.copyOfRange(allKeys, half1, newLen);
@@ -1054,6 +1059,94 @@ public class Branch<Key, Address> extends ANode<Key, Address> implements ISubtre
     }
 
     throw new RuntimeException("Unreachable");
+  }
+
+  @Override
+  public ANode removeContent(IStorage storage, Key key, Comparator<Key> cmp, Settings settings) {
+    int idx = search(key, cmp);
+    if (idx < 0) idx = -idx - 1;
+    if (idx == _len) return null; // key greater than everything → not present
+
+    ANode oldChild = child(storage, idx);
+    ANode newChild = oldChild.removeContent(storage, key, cmp, settings);
+    if (newChild == null) return null; // not present below
+
+    IBoundary boundary = settings.boundary();
+    IMeasure measureOps = settings.measure();
+
+    // The removed key was a boundary between child idx and idx+1 (at the children's level)
+    // iff keyLevel(key) >= this branch's level. Then those two children merge.
+    boolean mergeRight = idx < _len - 1 && boundary.keyLevel(key, settings) >= _level;
+
+    Object[] newChildren;
+    if (newChild instanceof Leaf && newChild._len == 0) {
+      // Child's whole subtree is gone (it collapsed to an empty Leaf — note its level no
+      // longer matches its siblings, so it can never participate in a merge): drop it. This
+      // subsumes the mergeRight case, since merging an empty node with its sibling yields
+      // exactly that sibling.
+      newChildren = new Object[_len - 1];
+      for (int i = 0; i < idx; i++)        newChildren[i] = child(storage, i);
+      for (int i = idx + 1; i < _len; i++) newChildren[i - 1] = child(storage, i);
+    } else if (mergeRight) {
+      // merge newChild with the right sibling child (junction merges recursively down).
+      ANode merged = newChild.mstMergeWith(child(storage, idx + 1), storage, settings);
+      newChildren = new Object[_len - 1];
+      for (int i = 0; i < idx; i++)            newChildren[i] = child(storage, i);
+      newChildren[idx] = merged;
+      for (int i = idx + 2; i < _len; i++)     newChildren[i - 1] = child(storage, i);
+    } else {
+      // no boundary removed at this level: just replace child idx
+      newChildren = new Object[_len];
+      for (int i = 0; i < _len; i++) newChildren[i] = child(storage, i);
+      newChildren[idx] = newChild;
+    }
+
+    int n = newChildren.length;
+    if (n == 0) {
+      // everything under this branch is gone
+      return new Leaf(0, (Key[]) new Object[0], settings);
+    }
+
+    Key[] keys = (Key[]) new Object[n];
+    for (int i = 0; i < n; i++) keys[i] = ((ANode<Key, Address>) newChildren[i]).maxKey();
+    long count = tryComputeSubtreeCountFromChildren(newChildren, n, storage);
+    Object measure = tryComputeMeasureFromChildren(newChildren, n, storage, measureOps);
+    return new Branch(_level, n, keys, null, newChildren, count, measure, _projCmp, settings);
+  }
+
+  @Override
+  public ANode mstMergeWith(ANode right, IStorage storage, Settings settings) {
+    Branch r = (Branch) right;
+    IBoundary boundary = settings.boundary();
+    IMeasure measureOps = settings.measure();
+
+    Object[] children;
+    int n;
+    // The junction — this branch's last child with right's first child — fuses ONLY when this
+    // branch's last child ended at the *removed* boundary (its maxKey is no longer a boundary
+    // at its level). If this branch's last child is still terminated by a LIVE boundary (e.g.
+    // its deepest boundary leaf was dropped, leaving a properly-terminated tail), the two must
+    // NOT fuse — plain concatenation preserves the live boundary. keyLevel(maxKey) >= _level
+    // ⇔ the last child (level _level-1) is boundary-terminated.
+    if (boundary.keyLevel(maxKey(), settings) >= _level) {
+      n = _len + r._len;
+      children = new Object[n];
+      for (int i = 0; i < _len; i++)   children[i] = child(storage, i);
+      for (int i = 0; i < r._len; i++) children[_len + i] = r.child(storage, i);
+    } else {
+      ANode junction = child(storage, _len - 1).mstMergeWith(r.child(storage, 0), storage, settings);
+      n = _len + r._len - 1;
+      children = new Object[n];
+      for (int i = 0; i < _len - 1; i++)  children[i] = child(storage, i);
+      children[_len - 1] = junction;
+      for (int i = 1; i < r._len; i++)    children[_len - 1 + i] = r.child(storage, i);
+    }
+
+    Key[] keys = (Key[]) new Object[n];
+    for (int i = 0; i < n; i++) keys[i] = ((ANode<Key, Address>) children[i]).maxKey();
+    long count = tryComputeSubtreeCountFromChildren(children, n, storage);
+    Object measure = tryComputeMeasureFromChildren(children, n, storage, measureOps);
+    return new Branch(_level, n, keys, null, children, count, measure, _projCmp, settings);
   }
 
   @Override

--- a/src-java/org/replikativ/persistent_sorted_set/CountBoundary.java
+++ b/src-java/org/replikativ/persistent_sorted_set/CountBoundary.java
@@ -14,12 +14,12 @@ public final class CountBoundary implements IBoundary {
   public static final CountBoundary INSTANCE = new CountBoundary();
 
   @Override
-  public boolean overflows(Object[] run, int len, int level, Settings s) {
-    return len > s.branchingFactor();
+  public int[] splitOnInsert(Object[] run, int len, int ins, int level, Settings s) {
+    if (len <= s.branchingFactor()) return null;   // fits in one node
+    return splitLengths(run, len, level, s);        // count: position-independent, ignores ins
   }
 
-  @Override
-  public int[] splitLengths(Object[] run, int len, int level, Settings s) {
+  private int[] splitLengths(Object[] run, int len, int level, Settings s) {
     if (level == 0) {
       // Leaf rule: ceil(len / bf) pieces, evenly sized, remainder distributed to the
       // later pieces (matches Leaf.add's baseLen + (i >= numLeaves - remainder) layout).

--- a/src-java/org/replikativ/persistent_sorted_set/CountBoundary.java
+++ b/src-java/org/replikativ/persistent_sorted_set/CountBoundary.java
@@ -1,0 +1,50 @@
+package org.replikativ.persistent_sorted_set;
+
+/**
+ * Default boundary policy: the historical count B-tree. Stateless singleton. Reproduces
+ * the existing split arithmetic byte-for-byte, so routing the node code through the seam
+ * with this policy is a pure refactor (verified against the full test suite).
+ *
+ * Two split shapes, keyed on level because leaves are always level 0 and branches ≥ 1:
+ *   - level 0 (leaf, {@code Leaf.java:139-156}): ceil(len / bf) even pieces, remainder to
+ *     the later pieces.
+ *   - level ≥ 1 (branch, {@code Branch.java:590}): exactly two, split at the midpoint.
+ */
+public final class CountBoundary implements IBoundary {
+  public static final CountBoundary INSTANCE = new CountBoundary();
+
+  @Override
+  public boolean overflows(Object[] run, int len, int level, Settings s) {
+    return len > s.branchingFactor();
+  }
+
+  @Override
+  public int[] splitLengths(Object[] run, int len, int level, Settings s) {
+    if (level == 0) {
+      // Leaf rule: ceil(len / bf) pieces, evenly sized, remainder distributed to the
+      // later pieces (matches Leaf.add's baseLen + (i >= numLeaves - remainder) layout).
+      int bf = s.branchingFactor();
+      int numLeaves = (len + bf - 1) / bf;
+      int[] lengths = new int[numLeaves];
+      int baseLen = len / numLeaves;
+      int remainder = len % numLeaves;
+      for (int i = 0; i < numLeaves; i++) {
+        lengths[i] = baseLen + (i >= numLeaves - remainder ? 1 : 0);
+      }
+      return lengths;
+    }
+    // Branch rule: two halves at the midpoint (half1 = len >>> 1).
+    int half1 = len >>> 1;
+    return new int[]{ half1, len - half1 };
+  }
+
+  @Override
+  public int keyLevel(Object key, Settings s) {
+    return 0;
+  }
+
+  @Override
+  public boolean contentDefined() {
+    return false;
+  }
+}

--- a/src-java/org/replikativ/persistent_sorted_set/IBoundary.java
+++ b/src-java/org/replikativ/persistent_sorted_set/IBoundary.java
@@ -1,0 +1,47 @@
+package org.replikativ.persistent_sorted_set;
+
+/**
+ * Pluggable split/merge decision (the "boundary policy"). Factors the only thing that
+ * varies between a count B-tree and a content-defined prolly/MST tree out of the node
+ * code: WHERE a node splits and WHETHER a run overflows. The array / Stitch / slot
+ * mechanics in Leaf/Branch are unchanged — they are driven by the answers here.
+ *
+ * The default policy is {@link CountBoundary} (even-division at branchingFactor), which
+ * reproduces the historical tree byte-for-byte. A content policy (e.g. MST leading-zeros)
+ * makes the structure a deterministic function of the keys (history-independent).
+ *
+ * Interface is grown incrementally as call sites are routed through it: this first cut
+ * covers the add/bulk overflow split. The remove-side predicates (underflows / joins /
+ * redistribute) and the MST root-promotion hooks are added with those sites.
+ */
+public interface IBoundary {
+
+  /**
+   * add/bulk: must this run be split into more than one node? Count: {@code len > bf}
+   * (ignores keys). MST: some key at index {@code < len-1} rises to {@code level+1}
+   * (a content boundary falls before the run's end). The run is the merged keys.
+   */
+  boolean overflows(Object[] run, int len, int level, Settings s);
+
+  /**
+   * add/bulk: partition an overflowing run into successive node lengths (summing to
+   * {@code len}). Count ignores {@code run} and divides evenly toward branchingFactor;
+   * MST cuts after each boundary key. The returned lengths drive the existing copy loop.
+   * Precondition: {@code overflows(len, level, s)} is true (callers handle the fit case).
+   */
+  int[] splitLengths(Object[] run, int len, int level, Settings s);
+
+  /**
+   * The level a key "rises to": 0 ⇒ leaf-only (no promotion), ≥1 ⇒ separator at that
+   * level. Count returns 0 for every key (⇒ purely length-driven). MST returns
+   * leadingZeros(hash(key)) / leadingZerosPerLevel.
+   */
+  int keyLevel(Object key, Settings s);
+
+  /**
+   * Whether boundaries are content-defined. False (count) keeps the legacy borrow path
+   * and in-place transient edits; true (MST) switches removes to merge-and-re-partition
+   * and enables multi-level root promotion.
+   */
+  boolean contentDefined();
+}

--- a/src-java/org/replikativ/persistent_sorted_set/IBoundary.java
+++ b/src-java/org/replikativ/persistent_sorted_set/IBoundary.java
@@ -17,19 +17,17 @@ package org.replikativ.persistent_sorted_set;
 public interface IBoundary {
 
   /**
-   * add/bulk: must this run be split into more than one node? Count: {@code len > bf}
-   * (ignores keys). MST: some key at index {@code < len-1} rises to {@code level+1}
-   * (a content boundary falls before the run's end). The run is the merged keys.
+   * The incremental single-insert splitter. {@code run} is the node's keys AFTER a single key
+   * was inserted at index {@code ins} (so {@code run[ins]} is the new key). Returns the
+   * successive node lengths if the node must split, or {@code null} if it stays one node.
+   *
+   * O(1) for MST: a node built by MST has no interior boundaries (only its terminator), so the
+   * only key that can create a new boundary is the inserted one — or, if it was appended past
+   * the old max ({@code ins == len-1}), the now-interior old max at {@code run[len-2]}. Count
+   * ignores {@code ins} and applies its size rule. Used by Leaf.add / Branch.add; bulk load
+   * chunks via {@link #keyLevel} directly.
    */
-  boolean overflows(Object[] run, int len, int level, Settings s);
-
-  /**
-   * add/bulk: partition an overflowing run into successive node lengths (summing to
-   * {@code len}). Count ignores {@code run} and divides evenly toward branchingFactor;
-   * MST cuts after each boundary key. The returned lengths drive the existing copy loop.
-   * Precondition: {@code overflows(len, level, s)} is true (callers handle the fit case).
-   */
-  int[] splitLengths(Object[] run, int len, int level, Settings s);
+  int[] splitOnInsert(Object[] run, int len, int ins, int level, Settings s);
 
   /**
    * The level a key "rises to": 0 ⇒ leaf-only (no promotion), ≥1 ⇒ separator at that

--- a/src-java/org/replikativ/persistent_sorted_set/IBoundary.java
+++ b/src-java/org/replikativ/persistent_sorted_set/IBoundary.java
@@ -42,4 +42,13 @@ public interface IBoundary {
    * and enables multi-level root promotion.
    */
   boolean contentDefined();
+
+  /**
+   * A serializable descriptor that lets a reader reconstruct this policy (e.g. the Clojure map
+   * {@code {:type :mst :lzpl 6}}), or {@code null} for the default count policy. Rides in the
+   * fressian blob's per-node config (NOT in the content hash), so a restored MST store is
+   * self-describing and cannot be silently mutated as a count tree. Returned as Object because
+   * the descriptor is consumer-domain EDN; the matching {@code boundary-resolver} rebuilds it.
+   */
+  default Object descriptor() { return null; }
 }

--- a/src-java/org/replikativ/persistent_sorted_set/Leaf.java
+++ b/src-java/org/replikativ/persistent_sorted_set/Leaf.java
@@ -85,8 +85,10 @@ public class Leaf<Key, Address> extends ANode<Key, Address> implements ISubtreeC
     ILeafProcessor processor = settings.leafProcessor();
     boolean processorWillFire = processor != null && processor.shouldProcess(_len + 1, settings);
 
-    // can modify array in place (only if processor won't fire)
-    if (editable() && _len < _keys.length && !processorWillFire) {
+    // can modify array in place (only if processor won't fire). Content (MST) mode opts out:
+    // an in-place insert would skip the boundary split, so a transient batch (e.g. yggdrasil's
+    // into-based set-union) must take the persistent split path that consults the boundary.
+    if (editable() && _len < _keys.length && !processorWillFire && !settings.boundary().contentDefined()) {
       if (ins == _len) {
         _keys[_len] = key;
         _len += 1;
@@ -127,13 +129,13 @@ public class Leaf<Key, Address> extends ANode<Key, Address> implements ISubtreeC
       }
     }
 
-    // split-seam: the boundary policy decides whether the run overflows one leaf and,
+    // split-seam: the boundary policy decides whether this single insert overflows the leaf and,
     // if so, how to partition it. Count ⇒ overflows at bf, even ceil(totalLen/bf) split
-    // (byte-identical to the historical arithmetic); MST ⇒ split at boundary keys.
-    IBoundary boundary = settings.boundary();
+    // (byte-identical); MST ⇒ O(1) check of the inserted key. null ⇒ stays one leaf.
+    int[] lengths = settings.boundary().splitOnInsert(allKeys, totalLen, ins, 0, settings);
 
     // Fits in single leaf
-    if (!boundary.overflows(allKeys, totalLen, 0, settings)) {
+    if (lengths == null) {
       Leaf n = new Leaf(totalLen, allKeys, settings);
       if (_measure != null) {
         n._measure = n.tryComputeMeasure(storage);
@@ -142,7 +144,6 @@ public class Leaf<Key, Address> extends ANode<Key, Address> implements ISubtreeC
     }
 
     // Split into policy-chosen pieces (lengths sum to totalLen)
-    int[] lengths = boundary.splitLengths(allKeys, totalLen, 0, settings);
     ANode[] result = new ANode[lengths.length];
     int pos = 0;
     for (int i = 0; i < lengths.length; i++) {

--- a/src-java/org/replikativ/persistent_sorted_set/Leaf.java
+++ b/src-java/org/replikativ/persistent_sorted_set/Leaf.java
@@ -127,8 +127,13 @@ public class Leaf<Key, Address> extends ANode<Key, Address> implements ISubtreeC
       }
     }
 
+    // split-seam: the boundary policy decides whether the run overflows one leaf and,
+    // if so, how to partition it. Count ⇒ overflows at bf, even ceil(totalLen/bf) split
+    // (byte-identical to the historical arithmetic); MST ⇒ split at boundary keys.
+    IBoundary boundary = settings.boundary();
+
     // Fits in single leaf
-    if (totalLen <= settings.branchingFactor()) {
+    if (!boundary.overflows(allKeys, totalLen, 0, settings)) {
       Leaf n = new Leaf(totalLen, allKeys, settings);
       if (_measure != null) {
         n._measure = n.tryComputeMeasure(storage);
@@ -136,16 +141,12 @@ public class Leaf<Key, Address> extends ANode<Key, Address> implements ISubtreeC
       return new ANode[]{n};
     }
 
-    // Split into ceil(totalLen / BF) leaves (remainder goes to later leaves)
-    int bf = settings.branchingFactor();
-    int numLeaves = (totalLen + bf - 1) / bf;
-    ANode[] result = new ANode[numLeaves];
+    // Split into policy-chosen pieces (lengths sum to totalLen)
+    int[] lengths = boundary.splitLengths(allKeys, totalLen, 0, settings);
+    ANode[] result = new ANode[lengths.length];
     int pos = 0;
-    int baseLen = totalLen / numLeaves;
-    int remainder = totalLen % numLeaves;
-    for (int i = 0; i < numLeaves; i++) {
-      // Remainder distributed to later leaves (matches old half1 = totalLen >>> 1 behavior)
-      int leafLen = baseLen + (i >= numLeaves - remainder ? 1 : 0);
+    for (int i = 0; i < lengths.length; i++) {
+      int leafLen = lengths[i];
       Leaf n = new Leaf(leafLen, settings);
       ArrayUtil.copy(allKeys, pos, pos + leafLen, n._keys, 0);
       if (_measure != null) {
@@ -340,6 +341,38 @@ public class Leaf<Key, Address> extends ANode<Key, Address> implements ISubtreeC
       return new ANode[]{ left, newCenter, newRight };
     }
     throw new RuntimeException("Unreachable");
+  }
+
+  @Override
+  public ANode removeContent(IStorage storage, Key key, Comparator<Key> cmp, Settings settings) {
+    int idx = search(key, cmp);
+    if (idx < 0) return null; // not present
+
+    int newLen = _len - 1;
+    Key[] newKeys = (Key[]) new Object[newLen];
+    new Stitch(newKeys, 0)
+      .copyAll(_keys, 0, idx)
+      .copyAll(_keys, idx + 1, _len);
+    Leaf n = new Leaf(newLen, newKeys, settings);
+    if (settings.measure() != null) {
+      n._measure = n.tryComputeMeasure(storage);
+    }
+    return n;
+  }
+
+  @Override
+  public ANode mstMergeWith(ANode right, IStorage storage, Settings settings) {
+    Leaf r = (Leaf) right;
+    int n = _len + r._len;
+    Key[] keys = (Key[]) new Object[n];
+    new Stitch(keys, 0)
+      .copyAll(_keys, 0, _len)
+      .copyAll(r._keys, 0, r._len);
+    Leaf merged = new Leaf(n, keys, settings);
+    if (settings.measure() != null) {
+      merged._measure = merged.tryComputeMeasure(storage);
+    }
+    return merged;
   }
 
   @Override

--- a/src-java/org/replikativ/persistent_sorted_set/PersistentSortedSet.java
+++ b/src-java/org/replikativ/persistent_sorted_set/PersistentSortedSet.java
@@ -649,6 +649,18 @@ public class PersistentSortedSet<Key, Address> extends APersistentSortedSet<Key,
   }
 
   public PersistentSortedSet replace(Object oldKey, Object newKey, Comparator cmp) {
+    // split-seam (MST): an in-place replace keeps the tree's boundary structure, which is canonical
+    // ONLY when oldKey and newKey rise to the same level. When a partial comparator shifts the key
+    // hash across a level boundary the node would have to re-split/merge, so fall back to
+    // disjoin+cons (the history-independent rebuild). Count mode is position-only ⇒ always in-place.
+    // See doc/merkle-search-tree.md.
+    IBoundary boundary = _settings.boundary();
+    if (boundary.contentDefined()
+        && boundary.keyLevel(oldKey, _settings) != boundary.keyLevel(newKey, _settings)) {
+      if (!root().contains(_storage, (Key) oldKey, cmp)) return this; // not found ⇒ no-op
+      return disjoin(oldKey, cmp).cons(newKey, cmp);
+    }
+
     ANode[] nodes = root().replace(_storage, (Key) oldKey, (Key) newKey, cmp, _settings);
 
     // Not in set

--- a/src-java/org/replikativ/persistent_sorted_set/PersistentSortedSet.java
+++ b/src-java/org/replikativ/persistent_sorted_set/PersistentSortedSet.java
@@ -22,7 +22,10 @@ public class PersistentSortedSet<Key, Address> extends APersistentSortedSet<Key,
   public Object _root; // Object == ANode | SoftReference<ANode> | WeakReference<ANode>
   public int _count;
   public int _version;
-  public final Settings _settings;
+  // Not final: a lazily-restored root self-describes its split strategy (the boundary); root()
+  // adopts it on first materialization so conj/disj use the right splitter even when the restore
+  // opts didn't specify one (the restore-by path). Like the _root lazy cache, a one-time write.
+  public Settings _settings;
   public IStorage<Key, Address> _storage;
 
   public PersistentSortedSet() {
@@ -57,6 +60,13 @@ public class PersistentSortedSet<Key, Address> extends APersistentSortedSet<Key,
     if (root == null && _address != null) {
       root = _storage.restore(_address);
       _root = _settings.makeReference(root);
+      // self-describing boundary: a restored node carries its split strategy; adopt it so this
+      // set's own conj/disj use the right splitter even when restore opts didn't specify one.
+      // Idempotent for the root-handler restore path (settings already carry the boundary).
+      IBoundary nodeBoundary = root._settings.boundary();
+      if (nodeBoundary.contentDefined() && !_settings.boundary().contentDefined()) {
+        _settings = _settings.withBoundary(nodeBoundary);
+      }
     }
     // diff-buf: seed the projection comparator at the root; Branch.child propagates it down
     // as nodes materialize, so a leaf-parent can project buffered leaves with the set's

--- a/src-java/org/replikativ/persistent_sorted_set/PersistentSortedSet.java
+++ b/src-java/org/replikativ/persistent_sorted_set/PersistentSortedSet.java
@@ -111,6 +111,37 @@ public class PersistentSortedSet<Key, Address> extends APersistentSortedSet<Key,
   }
 
   /**
+   * Build the new root from the children the root's add() returned. Count ⇒ a single wrap
+   * (byte-identical). MST ⇒ promote by boundary level until one node remains: a separator
+   * whose key rises to level+1 ends a parent chunk, so one high-level key can grow several
+   * levels at once (rare; may leave degenerate single-child branches — history-independent,
+   * collapsing them is a follow-up). The rightmost child is never a cut (global max).
+   */
+  private ANode growRoot(ANode[] nodes) {
+    IBoundary boundary = _settings.boundary();
+    if (!boundary.contentDefined()) {
+      return makeBranchFromChildren(nodes);
+    }
+    while (nodes.length >= 2) {
+      int level = nodes[0].level() + 1;
+      int thresh = level + 1;
+      List<ANode> branches = new ArrayList<>();
+      int start = 0;
+      for (int i = 0; i < nodes.length; i++) {
+        boolean cut = i < nodes.length - 1
+                      && boundary.keyLevel(nodes[i].maxKey(), _settings) >= thresh;
+        if (cut || i == nodes.length - 1) {
+          branches.add(makeBranchFromChildren(Arrays.copyOfRange(nodes, start, i + 1)));
+          start = i + 1;
+        }
+      }
+      if (branches.size() == 1) return branches.get(0);
+      nodes = branches.toArray(new ANode[0]);
+    }
+    return nodes[0];
+  }
+
+  /**
    * Check whether all nodes in this tree have precomputed subtree counts.
    * When true, countSlice is guaranteed O(log n).
    * When false, countSlice may degrade to O(n) for subtrees missing counts.
@@ -494,7 +525,7 @@ public class PersistentSortedSet<Key, Address> extends APersistentSortedSet<Key,
       if (1 == nodes.length) {
         _root = nodes[0];
       } else if (nodes.length >= 2) {
-        _root = makeBranchFromChildren(nodes);
+        _root = growRoot(nodes);
       }
       // EARLY_EXIT case (nodes.length == 0): tree was modified in place, _address already cleared above
       // When processor is configured, count may differ from +1
@@ -512,7 +543,7 @@ public class PersistentSortedSet<Key, Address> extends APersistentSortedSet<Key,
     if (1 == nodes.length) {
       newRoot = nodes[0];
     } else {
-      newRoot = makeBranchFromChildren(nodes);
+      newRoot = growRoot(nodes);
     }
 
     // Use root's subtreeCount for exact count (works correctly even with processor)
@@ -527,6 +558,28 @@ public class PersistentSortedSet<Key, Address> extends APersistentSortedSet<Key,
   }
 
   public PersistentSortedSet disjoin(Object key, Comparator cmp) {
+    // split-seam (MST/content mode): sibling-free removeContent recursion, then collapse a
+    // single-child root (count path below is untouched / byte-identical).
+    if (_settings.boundary().contentDefined()) {
+      ANode newRoot = root().removeContent(_storage, (Key) key, cmp, _settings);
+      if (newRoot == null) return this; // not in set
+      if (_storage != null && _address != null) _storage.markFreed(_address);
+      while (newRoot instanceof Branch && newRoot._len == 1) {
+        newRoot = ((Branch) newRoot).child(_storage, 0);
+      }
+      if (editable()) {
+        _address = null;
+        _root = newRoot;
+        long rc = getSubtreeCount(newRoot);
+        _count = (rc >= 0) ? (int) rc : -1;
+        _version += 1;
+        return this;
+      }
+      long rc = getSubtreeCount(newRoot);
+      int newCount = (rc >= 0) ? (int) rc : -1;
+      return new PersistentSortedSet(_meta, _cmp, null, _storage, newRoot, newCount, _settings, _version + 1);
+    }
+
     ANode[] nodes = root().remove(_storage, (Key) key, null, null, cmp, _settings);
 
     // not in set

--- a/src-java/org/replikativ/persistent_sorted_set/Settings.java
+++ b/src-java/org/replikativ/persistent_sorted_set/Settings.java
@@ -102,7 +102,20 @@ public class Settings {
 
   // Returns a copy of these settings with a different boundary policy (e.g. MST). Preserves
   // edit state so it composes with transients. Used by the Clojure API to opt into prolly mode.
+  //
+  // A content-defined boundary is INCOMPATIBLE with two features and we reject/neutralize them
+  // here so the combination can't be constructed silently:
+  //  - leafProcessor: splitOnInsert assumes a single key was inserted; a processor that rewrites
+  //    multiple entries per op would violate that invariant ⇒ reject.
+  //  - diff-buffering: a buffered spine node is addressed by hash(anchor+diff), not its canonical
+  //    content hash, which defeats the cross-peer dedup MST exists for ⇒ force off.
   public Settings withBoundary(IBoundary boundary) {
+    if (boundary != null && boundary.contentDefined()) {
+      if (_leafProcessor != null)
+        throw new IllegalArgumentException(
+          "a content-defined boundary (MST) is incompatible with a leafProcessor");
+      return new Settings(_branchingFactor, _refType, _edit, _measure, _leafProcessor, 0, boundary);
+    }
     return new Settings(_branchingFactor, _refType, _edit, _measure, _leafProcessor, _diffBufSize, boundary);
   }
 

--- a/src-java/org/replikativ/persistent_sorted_set/Settings.java
+++ b/src-java/org/replikativ/persistent_sorted_set/Settings.java
@@ -15,19 +15,24 @@ public class Settings {
   // entirely, so every code path is byte-identical to baseline PSS (invariant I0).
   // Design + the IStorage slots contract: doc/diff-buffering.md.
   public final int _diffBufSize;
+  // split-seam: pluggable split/merge decision. null ⇒ CountBoundary (historical count
+  // B-tree, byte-identical). A content policy (MST) makes the tree history-independent.
+  // See .internal/SPLIT_SEAM_DESIGN.md. Threaded like _diffBufSize (incl. editable carry).
+  public final IBoundary _boundary;
 
   // Canonical edit-carrying constructor (does not normalize; callers pass already-normalized
   // values). Used by editable() — which threads BOTH the set's branchingFactor and diffBufSize
   // through unchanged, so a transient preserves them. (The pre-diff-buf 5-arg edit ctor was
   // removed: it was unused and, lacking a diffBufSize arg, would have silently reset it to the
   // sysprop default.)
-  public Settings(int branchingFactor, RefType refType, AtomicBoolean edit, IMeasure measure, ILeafProcessor leafProcessor, int diffBufSize) {
+  public Settings(int branchingFactor, RefType refType, AtomicBoolean edit, IMeasure measure, ILeafProcessor leafProcessor, int diffBufSize, IBoundary boundary) {
     _branchingFactor = branchingFactor;
     _refType = refType;
     _edit = edit;
     _measure = measure;
     _leafProcessor = leafProcessor;
     _diffBufSize = diffBufSize;
+    _boundary = boundary;
   }
 
   public Settings() {
@@ -64,6 +69,7 @@ public class Settings {
     _measure = measure;
     _leafProcessor = leafProcessor;
     _diffBufSize = diffBufSize < 0 ? 0 : diffBufSize;
+    _boundary = null; // count default; MST configured via withBoundary()
   }
 
   // diff-buf: diff-buffering is OFF by default (0 ⇒ byte-identical baseline, invariant
@@ -88,6 +94,18 @@ public class Settings {
     return _branchingFactor;
   }
 
+  // split-seam: the active boundary policy. Defaults to the count B-tree (byte-identical
+  // baseline) when none is configured, so all split sites can route through the seam.
+  public IBoundary boundary() {
+    return _boundary == null ? CountBoundary.INSTANCE : _boundary;
+  }
+
+  // Returns a copy of these settings with a different boundary policy (e.g. MST). Preserves
+  // edit state so it composes with transients. Used by the Clojure API to opt into prolly mode.
+  public Settings withBoundary(IBoundary boundary) {
+    return new Settings(_branchingFactor, _refType, _edit, _measure, _leafProcessor, _diffBufSize, boundary);
+  }
+
   public int expandLen() {
     return 8;
   }
@@ -108,7 +126,7 @@ public class Settings {
   public Settings editable(boolean value) {
     assert !editable();
     assert value == true;
-    Settings s = new Settings(_branchingFactor, _refType, new AtomicBoolean(value), _measure, _leafProcessor, _diffBufSize);
+    Settings s = new Settings(_branchingFactor, _refType, new AtomicBoolean(value), _measure, _leafProcessor, _diffBufSize, _boundary);
     return s;
   }
 

--- a/test-clojure/org/replikativ/persistent_sorted_set/test/fressian_handlers.cljc
+++ b/test-clojure/org/replikativ/persistent_sorted_set/test/fressian_handlers.cljc
@@ -102,6 +102,25 @@
           expected (vec (remove #(zero? (mod % 7)) elems))]
       (is (= expected back)))))
 
+(deftest mst-durable-remove-roundtrip
+  (testing "MST conj/store/restore/disj/store/restore on a fressian-backed storage (BOTH platforms).
+            Exercises the storage-aware MST remove (children materialized via branch/child, not read
+            directly) and the boundary self-restoring (root adopts the node's strategy)."
+    (let [storage  (make-fress-storage 64 0)
+          elems    (vec (range 3000))
+          s0       (reduce (fn [s e] (set/conj s e compare))
+                           (set/sorted-set* {:storage storage :branching-factor 64
+                                             :boundary (bnd/mst-boundary 5)})
+                           (shuffle elems))
+          a0       (set/store s0 storage)
+          s1       (set/restore a0 storage)                  ; boundary not in opts → self-restores
+          s2       (reduce (fn [s e] (set/disj s e compare)) s1 (range 0 3000 7))  ; storage-aware remove
+          a2       (set/store s2 storage)
+          back     (vec (set/restore a2 storage))
+          expected (vec (remove #(zero? (mod % 7)) elems))]
+      (is (= elems (vec s1)) "restored set correct before removes")
+      (is (= expected back) "durable MST remove (after store/restore) yields the right elements"))))
+
 ;; JVM-only: ref-type is policy DATA (an enum), so it rides in the blob and a node reconstructs with
 ;; its own caching policy even when the reader knows nothing about it (the konserve-sync rootless
 ;; case). SOFT (the default) is omitted so common blobs are byte-unchanged; a read-time `:ref-type`

--- a/test-clojure/org/replikativ/persistent_sorted_set/test/fressian_handlers.cljc
+++ b/test-clojure/org/replikativ/persistent_sorted_set/test/fressian_handlers.cljc
@@ -360,13 +360,15 @@
      (deftest mst-codec-history-independent
        (testing "two insertion orders of the same set ⇒ identical content-addressed root through the codec"
          (let [els (vec (range 4000))
-               ra  (set/store (mst-set (ca-store) 5 (shuffle els)) (ca-store))
-               rb  (set/store (mst-set (ca-store) 5 (shuffle els)) (ca-store))
+               store-mst (fn [order] (let [st (ca-store)] (set/store (mst-set st 5 order) st)))
+               store-cnt (fn [order] (let [st (ca-store)]
+                                       (set/store (reduce #(set/conj %1 %2 compare)
+                                                          (set/sorted-set* {:storage st :branching-factor 64}) order) st)))
+               ra  (store-mst (shuffle els))
+               rb  (store-mst (shuffle els))
                ;; count build of the same elements is order-dependent ⇒ generally different roots
-               rc1 (set/store (reduce #(set/conj %1 %2 compare)
-                                      (set/sorted-set* {:storage (ca-store) :branching-factor 64}) (sort els)) (ca-store))
-               rc2 (set/store (reduce #(set/conj %1 %2 compare)
-                                      (set/sorted-set* {:storage (ca-store) :branching-factor 64}) (reverse (sort els))) (ca-store))]
+               rc1 (store-cnt (sort els))
+               rc2 (store-cnt (reverse (sort els)))]
            (is (= ra rb) "MST: same key set, different order ⇒ same content-addressed root")
            (is (not= rc1 rc2) "count: different order ⇒ different root (the gap MST closes)"))))
 

--- a/test-clojure/org/replikativ/persistent_sorted_set/test/fressian_handlers.cljc
+++ b/test-clojure/org/replikativ/persistent_sorted_set/test/fressian_handlers.cljc
@@ -9,6 +9,8 @@
   (:require [clojure.test :refer [deftest is testing]]
             [org.replikativ.persistent-sorted-set :as set]
             [org.replikativ.persistent-sorted-set.fressian :as pss-fress]
+            [org.replikativ.persistent-sorted-set.boundary :as bnd]
+            [hasch.core :as hasch]
             #?(:clj  [clojure.data.fressian :as fress]
                :cljs [fress.api :as fress])
             #?(:cljs [org.replikativ.persistent-sorted-set.impl.storage :refer [IStorage]]))
@@ -29,7 +31,8 @@
        ;; consumer's measure-ops + a default-bf fallback for pre-bf blobs.
        (-> (merge fress/clojure-read-handlers
                   (pss-fress/read-handlers {:measure-ops (.-_measure settings)
-                                            :default-bf   (.branchingFactor settings)}))
+                                            :default-bf   (.branchingFactor settings)
+                                            :boundary-resolver bnd/boundary-from-descriptor}))
            fress/associative-lookup))
      (defn- ser ^bytes [node]
        (let [out (ByteArrayOutputStream.)]
@@ -51,7 +54,8 @@
      (defn- ser [node] (fress/write node :handlers pss-fress/write-handlers))
      (defn- deser [settings bs]
        (fress/read bs :handlers (pss-fress/read-handlers {:measure-ops (:measure settings)
-                                                          :default-bf  (:branching-factor settings)})))
+                                                          :default-bf  (:branching-factor settings)
+                                                          :boundary-resolver bnd/boundary-from-descriptor})))
      (defrecord FressStorage [*disk settings]
        IStorage
        (store    [_ node _opts] (let [a (random-uuid)] (swap! *disk assoc a (ser node)) a))
@@ -312,3 +316,64 @@
            (is (instance? PersistentSortedSet (:root back)))
            (is (= (vec (range 200)) (vec (:root back))) "the PSS root resolves storage + lazy-loads")
            (finally (pss-fress/unregister-storage! :store/x)))))))
+
+;; ---- MST (content-defined boundary) durable round-trip (JVM) ------------------------------
+;; Content-addressed storage (address = hasch/uuid(node->map)) so equal trees share a root
+;; address: proves history-independence survives the real codec, that restore reconstructs the
+;; MST boundary from the self-describing blob, and that mutate-after-restore stays canonical.
+#?(:clj
+   (do
+     (defn- ca-store []
+       (let [*disk (atom {})
+             settings (Settings. (int 64) nil nil nil (int 0))]   ; boundary comes from the blob
+         (reify IStorage
+           (store     [_ node] (let [a (str (hasch/uuid (pss-fress/node->map node)))]
+                                 (swap! *disk assoc a (ser node)) a))
+           (accessed  [_ _addr] nil)
+           (restore   [_ addr] (deser settings (get @*disk addr)))
+           (markFreed [_ _addr] nil) (isFreed [_ _addr] false) (freedInfo [_ _addr] nil))))
+
+     (defn- mst-set [storage lzpl elems]
+       (reduce (fn [s e] (set/conj s e compare))
+               (set/sorted-set* {:storage storage :branching-factor 64 :boundary (bnd/mst-boundary lzpl)})
+               elems))
+
+     (deftest mst-codec-history-independent
+       (testing "two insertion orders of the same set ⇒ identical content-addressed root through the codec"
+         (let [els (vec (range 4000))
+               ra  (set/store (mst-set (ca-store) 5 (shuffle els)) (ca-store))
+               rb  (set/store (mst-set (ca-store) 5 (shuffle els)) (ca-store))
+               ;; count build of the same elements is order-dependent ⇒ generally different roots
+               rc1 (set/store (reduce #(set/conj %1 %2 compare)
+                                      (set/sorted-set* {:storage (ca-store) :branching-factor 64}) (sort els)) (ca-store))
+               rc2 (set/store (reduce #(set/conj %1 %2 compare)
+                                      (set/sorted-set* {:storage (ca-store) :branching-factor 64}) (reverse (sort els))) (ca-store))]
+           (is (= ra rb) "MST: same key set, different order ⇒ same content-addressed root")
+           (is (not= rc1 rc2) "count: different order ⇒ different root (the gap MST closes)"))))
+
+     (deftest mst-restore-preserves-boundary
+       (testing "restore reconstructs the MST boundary ⇒ mutate-after-restore is canonical"
+         (let [els    (vec (range 3000))
+               st     (ca-store)
+               root   (set/store (mst-set st 5 (shuffle els)) st)
+               s'     (set/restore root st)                       ; restored — boundary self-restores
+               ;; mutate the restored set: add 9000 (a fresh key) and remove 1500
+               s''    (-> s' (set/conj 9000 compare) (set/disj 1500 compare))
+               r''    (set/store s'' st)                          ; same store (lazy children live here)
+               survivors (-> (into (sorted-set) els) (conj 9000) (disj 1500))
+               rfresh (set/store (mst-set (ca-store) 5 (shuffle (vec survivors))) (ca-store))]
+           (is (= (vec s') (sort els)) "restored elements correct")
+           (is (= (vec s'') (vec survivors)) "mutated-after-restore elements correct")
+           (is (= r'' rfresh)
+               "mutate-after-restore yields the SAME tree as a fresh MST build (boundary preserved)"))))
+
+     (deftest mst-self-describing-blob
+       (testing "the boundary descriptor rides in the node AND root blobs (self-describing restore)"
+         (let [s (reduce #(set/conj %1 %2 compare)
+                         (set/sorted-set* {:branching-factor 64 :boundary (bnd/mst-boundary 5)})
+                         (range 2000))]
+           (is (= {:type :mst :lzpl 5} (:boundary (#'pss-fress/node-config (.root ^PersistentSortedSet s))))
+               "node-config self-describes the MST boundary")
+           ;; reconstruct the strategy from the descriptor alone, no consumer interaction
+           (is (= true (.contentDefined (bnd/boundary-from-descriptor {:type :mst :lzpl 5})))
+               "PSS resolves the descriptor internally"))))))

--- a/test-clojure/org/replikativ/persistent_sorted_set/test/mst.cljc
+++ b/test-clojure/org/replikativ/persistent_sorted_set/test/mst.cljc
@@ -57,6 +57,54 @@
                  :keys      (mapv #(key-at node %) (range (node-len node)))
                  :addresses (mapv #(merkle (node-child node %)) (range (node-len node)))})))
 
+(defn- node-max
+  "A node's maximum key = its last key (leaf) / last separator (branch)."
+  [node] (key-at node (dec (node-len node))))
+
+(defn- leaf-depths [node d]
+  (if (instance? Leaf node)
+    [d]
+    (mapcat #(leaf-depths (node-child node %) (inc d)) (range (node-len node)))))
+
+(defn mst-violation
+  "Structural-invariant validator for canonical MST (test B). Returns nil if the subtree
+   rooted at `node` is a canonical Merkle Search Tree for the given `lz` (leadingZeros-per-
+   level), else a map describing the first violation. Checks the MST-specific properties that
+   element-equality cannot see:
+     1. no MISSING split: every interior leaf key (all but the node's own max) is level-0 —
+        a boundary key inside a leaf would mean the leaf should have been split there;
+     2. no MISSING/EXTRA split at branches: every interior separator (all but the node's own
+        max) is a boundary at the branch's level — i.e. key-level >= branch level, so its
+        child is correctly boundary-terminated and the branch is split at exactly the boundaries;
+     3. B+ shape: each separator equals its child's max key;
+     4. height-balance: all leaves sit at the same depth.
+   The node's own max key (last index) is exempt at every level — it is validated by the
+   parent's separator check, or is the global rightmost spine max (no boundary required)."
+  [node lz]
+  (or
+    ;; (4) height-balance — check once at the top
+   (let [ds (leaf-depths node 0)]
+     (when-not (apply = ds) {:unbalanced-leaf-depths (distinct ds)}))
+   (letfn [(walk [node]
+             (if (instance? Leaf node)
+                ;; (1) interior leaf keys must NOT be boundaries
+               (first (for [i (range (dec (node-len node)))
+                            :when (>= (b/key-level (key-at node i) lz) 1)]
+                        {:leaf-interior-boundary (key-at node i) :index i}))
+               (let [n (node-len node) lvl (node-level node)]
+                 (or
+                    ;; (2) interior separators must be boundaries at this level
+                  (first (for [i (range (dec n))
+                               :when (< (b/key-level (key-at node i) lz) lvl)]
+                           {:separator-not-boundary (key-at node i) :level lvl :index i}))
+                    ;; (3) separator == child max
+                  (first (for [i (range n)
+                               :when (not= (key-at node i) (node-max (node-child node i)))]
+                           {:separator-mismatch i :level lvl}))
+                    ;; recurse
+                  (first (keep #(walk (node-child node %)) (range n)))))))]
+     (walk node))))
+
 (defn- mst-set-lz [ks lz] (reduce conj (pss/sorted-set* {:boundary (b/mst-boundary lz)}) ks))
 
 ;; ---------------------------------------------------------------------------------------
@@ -148,7 +196,7 @@
   ;; order-independence reaches the same address.
   (testing "root Merkle address matches the JVM reference on this platform"
     (are [n lz expected]
-        (= expected (str (merkle (root-of (mst-set-lz (shuffle (vec (range n))) lz)))))
+         (= expected (str (merkle (root-of (mst-set-lz (shuffle (vec (range n))) lz)))))
       5000 4 "3763fc7d-cef1-5a60-a65d-46bce9dcb393"
       5000 6 "2c6ecf6a-0883-5da7-8dab-6309a819cedb"
       1000 5 "2c95d9db-32db-57a7-8b56-480de2cfd1b8")))
@@ -161,18 +209,58 @@
 
 (defspec prop-order-independence 20
   (prop/for-all [ks (gen/such-that seq (gen/set gen/large-integer))]
-    (let [v (vec ks)
-          shapes (map (comp root-shape mst-set) [(sort v) (reverse (sort v)) (shuffle v)])]
-      (and (apply = shapes)
-           (= (seq (mst-set (shuffle v))) (seq (sort v)))))))
+                (let [v (vec ks)
+                      sets (map mst-set [(sort v) (reverse (sort v)) (shuffle v)])]
+                  (and (apply = (map root-shape sets))
+                       (every? #(nil? (mst-violation (root-of %) lzpl)) sets)
+                       (= (seq (mst-set (shuffle v))) (seq (sort v)))))))
 
 (defspec prop-remove-independence 20
   (prop/for-all [ks (gen/such-that #(> (count %) 2) (gen/set gen/large-integer))
                  seed gen/nat]
-    (let [v (vec ks)
-          drop-set (set (take (mod seed (count v)) (shuffle v)))
-          survivors (sort (remove drop-set v))
-          removed (reduce disj (mst-set (shuffle v)) (shuffle (vec drop-set)))
-          fresh (mst-set (shuffle survivors))]
-      (and (= (seq removed) survivors)
-           (= (root-shape removed) (root-shape fresh))))))
+                (let [v (vec ks)
+                      drop-set (set (take (mod seed (count v)) (shuffle v)))
+                      survivors (sort (remove drop-set v))
+                      removed (reduce disj (mst-set (shuffle v)) (shuffle (vec drop-set)))
+                      fresh (mst-set (shuffle survivors))]
+                  (and (= (seq removed) survivors)
+                       (nil? (mst-violation (root-of removed) lzpl))
+                       (= (root-shape removed) (root-shape fresh))))))
+
+;; =============================================================================
+;; Model-based testing under INTERLEAVED operations (test A).
+;;
+;; The analog of generative.cljc's `operations-match-sorted-set`, specialized to MST.
+;; A random INTERLEAVED sequence of conj/disj (not phased build-then-remove) drives the
+;; MST in lock-step with clojure.core/sorted-set, then we assert all three guarantees at
+;; once on the final tree:
+;;   (a) ELEMENTS:      same contents as the sorted-set oracle;
+;;   (b) INVARIANTS:    the tree is a canonical MST (mst-violation = nil);
+;;   (c) CANONICALITY:  identical structure to a FRESH build of the survivors — i.e. full
+;;                      history-independence, now over arbitrary interleaved op orders, the
+;;                      regime the phased order/remove specs above never reach.
+;; Uses a small fanout (lzpl 3 ⇒ B≈8) so even modest N produces multi-level trees that
+;; exercise branch splits, merges, single-child spines and root grow/shrink. Runs on BOTH
+;; platforms; the cljs and JVM trees must be byte-identical for (c) to hold cross-platform.
+;; =============================================================================
+
+(def ^:const ilz 3)
+(defn- iset [ks] (mst-set-lz ks ilz))
+
+(def ^:private gen-op
+  (gen/tuple (gen/elements [:add :remove]) (gen/choose -400 400)))
+
+(defspec prop-interleaved-ops-match-and-canonical 60
+  (prop/for-all [init (gen/vector (gen/choose -400 400) 0 200)
+                 ops  (gen/vector gen-op 0 400)]
+                (let [[pss clj] (reduce (fn [[p c] [op v]]
+                                          (case op
+                                            :add    [(conj p v) (conj c v)]
+                                            :remove [(disj p v) (disj c v)]))
+                                        [(iset init) (into (sorted-set) init)]
+                                        ops)
+                      survivors (vec clj)]
+                  (and (= (vec pss) survivors)                                  ; (a) elements
+                       (nil? (mst-violation (root-of pss) ilz))                 ; (b) invariants
+                       (= (root-shape pss)                                      ; (c) canonical
+                          (root-shape (iset (shuffle survivors))))))))

--- a/test-clojure/org/replikativ/persistent_sorted_set/test/mst.cljc
+++ b/test-clojure/org/replikativ/persistent_sorted_set/test/mst.cljc
@@ -83,6 +83,18 @@
       (is (= (:shape (first results)) (root-shape fresh))
           "removed tree is byte-identical to a fresh build of the survivors"))))
 
+(deftest transient-add-canonical
+  (testing "transient batch conj (the editable in-place path) still splits at boundaries"
+    ;; yggdrasil's set-union uses (into a b), which conj!'s through a transient. The in-place
+    ;; add shortcut must NOT be taken in MST mode or boundary keys wouldn't split.
+    (let [n 4000
+          ks (vec (range n))
+          via-transient (persistent! (reduce conj! (transient (pss/sorted-set* {:boundary (mkb)})) (shuffle ks)))
+          via-persistent (mst-set (shuffle ks))]
+      (is (= (seq via-transient) (seq ks)) "elements correct")
+      (is (= (root-shape via-transient) (root-shape via-persistent))
+          "transient build is canonical (identical tree to persistent conj)"))))
+
 (deftest remove-stress
   ;; Many random (build-order, remove-order) trials at depth ≥3. The "boundary key alone in
   ;; its leaf, dropped, then the grandparent merges" case is rare (~1 in 15 trials), so a single

--- a/test-clojure/org/replikativ/persistent_sorted_set/test/mst.cljc
+++ b/test-clojure/org/replikativ/persistent_sorted_set/test/mst.cljc
@@ -4,12 +4,13 @@
    insert / merge / remove order. Runs on BOTH platforms (cljc) — the same battery exercising
    the JVM and the cljs implementations, which must produce identical structures. See
    .internal/SPLIT_SEAM_DESIGN.md."
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.test :refer [deftest is testing are]]
             [clojure.test.check.generators :as gen]
             [clojure.test.check.properties :as prop]
             [clojure.test.check.clojure-test :refer [defspec]]
             [org.replikativ.persistent-sorted-set :as pss]
             [org.replikativ.persistent-sorted-set.boundary :as b]
+            [hasch.core :as hasch]
             #?@(:cljs [[org.replikativ.persistent-sorted-set.leaf :refer [Leaf]]
                        [org.replikativ.persistent-sorted-set.branch :refer [Branch]]
                        [org.replikativ.persistent-sorted-set.arrays :as arrays]]))
@@ -45,6 +46,18 @@
   (if (instance? Leaf node)
     [node]
     (mapcat #(leaves (node-child node %)) (range (node-len node)))))
+
+(defn- merkle
+  "The tree's content address, computed bottom-up exactly like a content-addressed store
+   (hasch/uuid over each node's {:level :keys :addresses}). hasch is deterministic JVM↔cljs."
+  [node]
+  (if (instance? Leaf node)
+    (hasch/uuid {:level 0 :keys (mapv #(key-at node %) (range (node-len node)))})
+    (hasch/uuid {:level     (node-level node)
+                 :keys      (mapv #(key-at node %) (range (node-len node)))
+                 :addresses (mapv #(merkle (node-child node %)) (range (node-len node)))})))
+
+(defn- mst-set-lz [ks lz] (reduce conj (pss/sorted-set* {:boundary (b/mst-boundary lz)}) ks))
 
 ;; ---------------------------------------------------------------------------------------
 
@@ -126,6 +139,19 @@
           interior (butlast ls)]
       (is (every? (fn [lf] (>= (b/key-level (key-at lf (dec (node-len lf))) lzpl) 1)) interior)
           "interior leaf terminators are all boundary keys"))))
+
+(deftest cross-platform-structural-identity
+  ;; The full tree's content address (Merkle hash of the whole structure) must equal the
+  ;; JVM-computed reference on BOTH platforms — the gold-standard proof that JVM and cljs build
+  ;; the byte-identical tree (not just matching key-levels) and hash it identically. A cljs
+  ;; structural OR hashing divergence fails this. Built in shuffled order to also assert
+  ;; order-independence reaches the same address.
+  (testing "root Merkle address matches the JVM reference on this platform"
+    (are [n lz expected]
+        (= expected (str (merkle (root-of (mst-set-lz (shuffle (vec (range n))) lz)))))
+      5000 4 "3763fc7d-cef1-5a60-a65d-46bce9dcb393"
+      5000 6 "2c6ecf6a-0883-5da7-8dab-6309a819cedb"
+      1000 5 "2c95d9db-32db-57a7-8b56-480de2cfd1b8")))
 
 (deftest count-mode-unaffected
   (testing "no :boundary ⇒ default count B-tree, all elements correct"

--- a/test-clojure/org/replikativ/persistent_sorted_set/test/mst.cljc
+++ b/test-clojure/org/replikativ/persistent_sorted_set/test/mst.cljc
@@ -264,3 +264,31 @@
                        (nil? (mst-violation (root-of pss) ilz))                 ; (b) invariants
                        (= (root-shape pss)                                      ; (c) canonical
                           (root-shape (iset (shuffle survivors))))))))
+
+;; =============================================================================
+;; replace on an MST set must stay canonical (the boundary-aware guard).
+;;
+;; `replace` swaps a key in place when old/new compare EQUAL under the comparator. With a
+;; PARTIAL comparator ([id payload] compared by id) the new key can hash to a DIFFERENT
+;; boundary level than the old one — an in-place swap would then leave a non-canonical tree.
+;; The implementation detects the level change and falls back to disj+conj. This spec drives
+;; random payload replacements (which shift the key hash across level boundaries ~1/5 of the
+;; time at lzpl 3) and asserts the result is byte-identical to a fresh build of the post-
+;; replace element set. Runs on BOTH platforms.
+;; =============================================================================
+
+(def ^:private cmp-id (fn [a b] (compare (first a) (first b))))
+(defn- iset-by [pairs] (reduce conj (pss/sorted-set* {:comparator cmp-id :boundary (b/mst-boundary ilz)}) pairs))
+
+(defspec prop-replace-canonical 40
+  (prop/for-all [ids  (gen/such-that #(> (count %) 2) (gen/set (gen/choose -400 400)))
+                 seed gen/nat]
+                (let [idv      (vec ids)
+                      base     (iset-by (shuffle (mapv (fn [id] [id 0]) idv)))
+                      rep-ids  (set (take (mod seed (inc (count idv))) (shuffle idv)))
+                      replaced (reduce (fn [s id] (pss/replace s [id 0] [id (inc id)])) base rep-ids)
+                      expected (sort-by first (mapv (fn [id] (if (rep-ids id) [id (inc id)] [id 0])) idv))
+                      fresh    (iset-by (shuffle expected))]
+                  (and (= (seq replaced) expected)                              ; payloads correct
+                       (nil? (mst-violation (root-of replaced) ilz))            ; canonical MST
+                       (= (root-shape replaced) (root-shape fresh))))))         ; == fresh build

--- a/test-clojure/org/replikativ/persistent_sorted_set/test/mst.cljc
+++ b/test-clojure/org/replikativ/persistent_sorted_set/test/mst.cljc
@@ -1,0 +1,140 @@
+(ns org.replikativ.persistent-sorted-set.test.mst
+  "Content-defined (Merkle Search Tree) boundary mode — the history-independence property
+   that motivates the split-seam: same key set ⇒ identical node structure regardless of
+   insert / merge / remove order. Runs on BOTH platforms (cljc) — the same battery exercising
+   the JVM and the cljs implementations, which must produce identical structures. See
+   .internal/SPLIT_SEAM_DESIGN.md."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]
+            [clojure.test.check.clojure-test :refer [defspec]]
+            [org.replikativ.persistent-sorted-set :as pss]
+            [org.replikativ.persistent-sorted-set.boundary :as b]
+            #?@(:cljs [[org.replikativ.persistent-sorted-set.leaf :refer [Leaf]]
+                       [org.replikativ.persistent-sorted-set.branch :refer [Branch]]
+                       [org.replikativ.persistent-sorted-set.arrays :as arrays]]))
+  #?(:clj (:import [org.replikativ.persistent_sorted_set ANode Leaf Branch PersistentSortedSet])))
+
+(def ^:const lzpl 4) ;; small fanout (~16) so trees branch at modest N
+
+(defn- mkb [] (b/mst-boundary lzpl))
+(defn- mst-set [ks] (reduce conj (pss/sorted-set* {:boundary (mkb)}) ks))
+
+;; ---- portable node access (JVM Java fields vs cljs deftype fields) ---------------------
+(defn- node-len [node]
+  #?(:clj (.-_len ^ANode node) :cljs (arrays/alength (.-keys node))))
+(defn- key-at [node i]
+  #?(:clj (aget ^objects (.-_keys ^ANode node) i) :cljs (aget (.-keys node) i)))
+(defn- node-level [node]
+  #?(:clj (.-_level ^Branch node) :cljs (.-level node)))
+(defn- node-child [node i]
+  #?(:clj (aget ^objects (.-_children ^Branch node) i) :cljs (aget (.-children node) i)))
+(defn- root-of [s]
+  #?(:clj (.root ^PersistentSortedSet s) :cljs (.-root s)))
+
+(defn shape
+  "Canonical structural fingerprint: nested vectors of leaf key-runs + branch levels."
+  [node]
+  (if (instance? Leaf node)
+    [:L (mapv #(key-at node %) (range (node-len node)))]
+    [:B (node-level node) (mapv #(shape (node-child node %)) (range (node-len node)))]))
+
+(defn root-shape [s] (shape (root-of s)))
+
+(defn- leaves [node]
+  (if (instance? Leaf node)
+    [node]
+    (mapcat #(leaves (node-child node %)) (range (node-len node)))))
+
+;; ---------------------------------------------------------------------------------------
+
+(deftest order-independence-conj
+  (testing "same key set, different insert orders ⇒ identical structure"
+    (let [n 2000
+          ks (vec (range n))
+          orders [ks (vec (reverse ks)) (shuffle ks) (shuffle ks)
+                  (concat (shuffle (take (quot n 2) ks)) (shuffle (drop (quot n 2) ks)))]
+          shapes (map (comp root-shape mst-set) orders)]
+      (is (apply = shapes) "all insert orders yield the identical node tree")
+      (is (every? #(= (seq (mst-set %)) (seq (range n))) orders) "elements correct & sorted"))))
+
+(deftest bulk-equals-incremental
+  (testing "from-sorted-array (bulk) builds the identical tree as incremental conj"
+    (let [n 3000
+          ks (range n)
+          incremental (mst-set (shuffle ks))
+          bulk (pss/from-sorted-array compare (object-array ks) n {:boundary (mkb)})]
+      (is (= (root-shape bulk) (root-shape incremental)))
+      (is (= (seq bulk) (seq (sort ks)))))))
+
+(deftest remove-history-independence
+  (testing "build-then-remove ≡ fresh build of the survivors (structure), any order"
+    (let [n 2500
+          uni (vec (range n))
+          drop-set (set (take (quot n 3) (shuffle uni)))
+          survivors (sort (remove drop-set uni))
+          results (for [bo [(sort uni) (reverse (sort uni)) (shuffle uni)]
+                        ro [(sort drop-set) (shuffle (vec drop-set))]]
+                    (let [s (reduce disj (mst-set bo) ro)]
+                      {:elems (seq s) :shape (root-shape s)}))
+          fresh (mst-set (shuffle survivors))]
+      (is (every? #(= (:elems %) survivors) results) "elements correct after removes")
+      (is (apply = (map :shape results)) "all build/remove orders ⇒ identical structure")
+      (is (= (:shape (first results)) (root-shape fresh))
+          "removed tree is byte-identical to a fresh build of the survivors"))))
+
+(deftest remove-stress
+  ;; Many random (build-order, remove-order) trials at depth ≥3. The "boundary key alone in
+  ;; its leaf, dropped, then the grandparent merges" case is rare (~1 in 15 trials), so a single
+  ;; deterministic pass misses it — this stress reliably exercises mst-merge-with's junction guard.
+  (testing "remove stays canonical (== fresh build of survivors) across many random trials"
+    (let [n 1500
+          fails (atom 0)]
+      (dotimes [_ 60]
+        (let [uni (vec (range n))
+              drop-set (set (take (quot n 3) (shuffle uni)))
+              survivors (sort (remove drop-set uni))
+              removed (reduce disj (mst-set (shuffle uni)) (shuffle (vec drop-set)))
+              fresh (mst-set (shuffle survivors))]
+          (when (or (not= (seq removed) survivors)
+                    (not= (root-shape removed) (root-shape fresh)))
+            (swap! fails inc))))
+      (is (zero? @fails) (str @fails "/60 random remove trials diverged from a fresh build")))))
+
+(deftest remove-to-empty-and-readd
+  (let [n 1500 uni (vec (range n))
+        emptied (reduce disj (mst-set (shuffle uni)) (shuffle uni))]
+    (is (= 0 (count emptied)))
+    (is (= (seq (reduce conj emptied (shuffle uni))) (seq (sort uni))))))
+
+(deftest leaf-boundary-invariant
+  (testing "every non-rightmost leaf terminates on a key whose level ≥ 1 (a real boundary)"
+    (let [s (mst-set (shuffle (range 4000)))
+          ls (leaves (root-of s))
+          interior (butlast ls)]
+      (is (every? (fn [lf] (>= (b/key-level (key-at lf (dec (node-len lf))) lzpl) 1)) interior)
+          "interior leaf terminators are all boundary keys"))))
+
+(deftest count-mode-unaffected
+  (testing "no :boundary ⇒ default count B-tree, all elements correct"
+    (let [ks (shuffle (range 3000))
+          a (reduce conj (pss/sorted-set* {}) ks)]
+      (is (= (seq a) (seq (sort (range 3000))))))))
+
+(defspec prop-order-independence 20
+  (prop/for-all [ks (gen/such-that seq (gen/set gen/large-integer))]
+    (let [v (vec ks)
+          shapes (map (comp root-shape mst-set) [(sort v) (reverse (sort v)) (shuffle v)])]
+      (and (apply = shapes)
+           (= (seq (mst-set (shuffle v))) (seq (sort v)))))))
+
+(defspec prop-remove-independence 20
+  (prop/for-all [ks (gen/such-that #(> (count %) 2) (gen/set gen/large-integer))
+                 seed gen/nat]
+    (let [v (vec ks)
+          drop-set (set (take (mod seed (count v)) (shuffle v)))
+          survivors (sort (remove drop-set v))
+          removed (reduce disj (mst-set (shuffle v)) (shuffle (vec drop-set)))
+          fresh (mst-set (shuffle survivors))]
+      (and (= (seq removed) survivors)
+           (= (root-shape removed) (root-shape fresh))))))

--- a/test-clojure/org/replikativ/persistent_sorted_set/test/mst.cljc
+++ b/test-clojure/org/replikativ/persistent_sorted_set/test/mst.cljc
@@ -292,3 +292,20 @@
                   (and (= (seq replaced) expected)                              ; payloads correct
                        (nil? (mst-violation (root-of replaced) ilz))            ; canonical MST
                        (= (root-shape replaced) (root-shape fresh))))))         ; == fresh build
+
+;; Same property over a TRANSIENT batch of replaces — exercises the editable in-place path
+;; (and the disj!/conj! fallback) which the persistent spec above doesn't reach. The JVM and
+;; cljs propagation rules must agree here too (value-based in MST), else the trees diverge.
+(defspec prop-replace-canonical-transient 40
+  (prop/for-all [ids  (gen/such-that #(> (count %) 2) (gen/set (gen/choose -400 400)))
+                 seed gen/nat]
+                (let [idv      (vec ids)
+                      base     (iset-by (shuffle (mapv (fn [id] [id 0]) idv)))
+                      rep-ids  (set (take (mod seed (inc (count idv))) (shuffle idv)))
+                      replaced (persistent! (reduce (fn [t id] (pss/replace t [id 0] [id (inc id)]))
+                                                    (transient base) rep-ids))
+                      expected (sort-by first (mapv (fn [id] (if (rep-ids id) [id (inc id)] [id 0])) idv))
+                      fresh    (iset-by (shuffle expected))]
+                  (and (= (seq replaced) expected)
+                       (nil? (mst-violation (root-of replaced) ilz))
+                       (= (root-shape replaced) (root-shape fresh))))))

--- a/test-clojure/org/replikativ/persistent_sorted_set/test/mst_determinism.cljc
+++ b/test-clojure/org/replikativ/persistent_sorted_set/test/mst_determinism.cljc
@@ -1,0 +1,30 @@
+(ns org.replikativ.persistent-sorted-set.test.mst-determinism
+  "The cross-platform determinism linchpin: `boundary/key-level` MUST return the identical
+   integer on the JVM and in ClojureScript for every key, or a JVM writer and a cljs reader
+   diverge on tree structure. The expected vectors below were computed on the JVM; this test
+   runs on BOTH platforms, so a cljs hash/leading-zeros divergence fails it. See
+   .internal/SPLIT_SEAM_DESIGN.md."
+  (:require [clojure.test :refer [deftest is]]
+            [org.replikativ.persistent-sorted-set.boundary :as b]))
+
+(def battery
+  (vec (concat (range 0 40)
+               ["a" "hello" "" "zzz" "datom" "the quick brown fox"]
+               [:kw :ns/kw 'sym :a/b]
+               [[1 2] [1 2 3] [:a 1 "x"] [0] [99 99]]
+               [1.5 -1 -42 true 9999999])))
+
+;; Known answers computed on the JVM (hasch.fast + Integer/numberOfLeadingZeros).
+(def expected-lzpl1
+  [0 3 0 1 2 0 0 0 0 0 0 0 0 0 3 1 0 0 1 0 1 0 2 0 1 0 0 0 2 1 0 3 1 0 3 1 1 2 0 0
+   1 0 0 4 0 1 1 1 2 0 1 0 1 1 0 1 3 0 1 0])
+
+(def expected-lzpl2
+  [0 1 0 0 1 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0 0 0 1 0 0 1 0 0 1 0 0 1 0 0
+   0 0 0 2 0 0 0 0 1 0 0 0 0 0 0 0 1 0 0 0])
+
+(deftest key-level-cross-platform
+  (is (= expected-lzpl1 (mapv #(b/key-level % 1) battery))
+      "key-level (lzpl 1) matches the JVM-computed reference on this platform")
+  (is (= expected-lzpl2 (mapv #(b/key-level % 2) battery))
+      "key-level (lzpl 2) matches the JVM-computed reference on this platform"))


### PR DESCRIPTION
## What

Two threads of work on the content-defined boundary (Merkle Search Tree / prolly) feature:

### 1. Property-test coverage for MST (`test/mst.cljc`)
The MST suite was thinner than the count generative suite — it tested history-independence only under *phased* (build-then-bulk-remove) operations and had no structural validator. This closes both gaps:

- **`mst-violation`** — a canonical-MST structural validator (test B): no missing leaf split, every interior separator is a boundary at its level, separator == child max, height-balance. Verified to have teeth (a count B-tree fed through it is flagged). Wired into the existing order/remove-independence specs.
- **`prop-interleaved-ops-match-and-canonical`** — the MST analog of count's `operations-match-sorted-set` (test A): a random **interleaved** `conj`/`disj` sequence driven in lock-step with `clojure.core/sorted-set`, asserting on the final tree (a) elements match the oracle, (b) MST invariants hold, (c) byte-identity to a fresh build of the survivors — i.e. full history-independence over *arbitrary* op orders.

Green on both JVM (194 tests / 53k assertions) and cljs (132 tests / 1.7k assertions).

### 2. Documentation overhaul
- README rewritten into the replikativ house style (badges, code-first quick start, feature bullets deep-linking to `doc/`). Surfaces the two features that had **zero README coverage**: content-defined boundaries (MST) and the canonical Fressian serialization. Dev/CI moved to the bottom; Nikita Prokopov's attribution preserved; install uses `LATEST`.
- New **`doc/merkle-search-tree.md`** — the MST level function, cross-platform determinism, geometric size distribution, `conj`/`disj` canonicality, self-describing serialization, and the diff-buf/leaf-processor incompatibilities.
- New **`doc/README.md`** documentation index.

### 3. Formatting
- `clj -M:ffix` whitespace normalization of `branch.cljs`/`btset.cljs` (pre-existing indentation drift on main), isolated in its own commit.

## Performance note
Separately verified that the boundary abstraction did **not** regress the default count B-tree path: an interleaved A/B benchmark (`f441ed0` pre-seam vs HEAD) shows the seam-sensitive ops (`conj`/`conj!`/`disj`) within the noise floor set by seam-insensitive controls (`contains`/`reduce`). In count mode the `boundary()`/`splitOnInsert`/`contentDefined` call sites are monomorphic, so the JIT inlines them away. No code change from this — investigation only.