### PR TITLE
deps: bump partial-cps 0.1.51 → 0.1.59 (cljs 1.12 await-clash fix)

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src-clojure" "target/classes"]
  :deps
  {org.clojure/clojure {:mvn/version "1.12.0"}
-  is.simm/partial-cps {:mvn/version "0.1.51"}}
+  is.simm/partial-cps {:mvn/version "0.1.59"}}
  :deps/prep-lib {:ensure "target/classes"
                  :alias :build
                  :fn java}


### PR DESCRIPTION
Bumps `is.simm/partial-cps` 0.1.51 → 0.1.59.

## Why
ClojureScript 1.12 added a native `cljs.core/await` **macro** (async-interop) that is auto-referred into every ns and, being a macro, wins over a `:refer`'d `await` in call position. That clashed with partial-cps's `await` and broke `btset.cljs`'s storage await path on cljs ≥1.12.

partial-cps 0.1.59 fixes this centrally: it registers `cljs.core/await` as the **same CPS breakpoint** as partial-cps's own `await`, so a bare `(await x)` inside a partial-cps `async` is CPS-transformed regardless of which `await` it resolves to — no per-ns `(:refer-clojure :exclude [await])` needed.

## Verification (toolchain already on cljs 1.12.42 / shadow-cljs 3.2.0)
- **JVM** (`clojure -M:test`): 196 tests, 52997 assertions, **0 failures, 0 errors**
- **cljs node** (`shadow release node-tests && node …`): 134 tests, 1688 assertions, **0 failures, 0 errors** — clean compile (await clash gone) + clean node exit

First step of the bottom-up partial-cps 0.1.59 propagation (PSS → yggdrasil → spindel).