### PR TITLE
fix(cljs): widen iterator path field so MST oversized nodes iterate fully

### DIFF
--- a/src-clojure/org/replikativ/persistent_sorted_set/btset.cljs
+++ b/src-clojure/org/replikativ/persistent_sorted_set/btset.cljs
@@ -469,9 +469,19 @@
 
 (def ^:const EMPTY_PATH (js* "0n"))
 
-(defn- bits-per-level [^BTSet set]
-  (let [bf (get (.-settings set) :branching-factor)]
-    (Math/ceil (Math/log2 bf))))
+(defn- bits-per-level [^BTSet _set]
+  ;; The iterator packs one index PER TREE LEVEL into a single BigInt path,
+  ;; `bits-per-level` bits each (`path-get`/`path-set` shift+mask by this width).
+  ;; A COUNT B-tree node is always ≤ branching-factor, so `ceil(log2 bf)` bits
+  ;; sufficed historically. But an MST content-defined node can EXCEED
+  ;; branching-factor (the boundary cuts at content keys, not by size — with no
+  ;; boundary key in a range a node simply grows). Sizing the field by
+  ;; `ceil(log2 bf)` then MASKS any index ≥ bf on read (e.g. `199 & 63 = 7`),
+  ;; truncating the path and silently dropping the tail of `seq`/`slice`/`rseq`.
+  ;; Use a fixed 32-bit field per level — matching the JVM's `int[]`-per-level
+  ;; path — so an index never overflows for any realistically sized node (a node
+  ;; with > 2^32 entries is physically impossible). BigInt absorbs the wider path.
+  32)
 
 (defn- max-len [^BTSet set]
   (get (.-settings set) :branching-factor))

--- a/test-clojure/org/replikativ/persistent_sorted_set/test/mst_iteration.cljs
+++ b/test-clojure/org/replikativ/persistent_sorted_set/test/mst_iteration.cljs
@@ -1,0 +1,31 @@
+(ns org.replikativ.persistent-sorted-set.test.mst-iteration
+  "Regression: an MST content-defined boundary splits a node only at *boundary
+   keys* (hashes with >= lzpl leading zeros), NOT by size — so a node can hold far
+   MORE than `branching-factor` keys when no boundary key falls in its range. The
+   cljs iterator packs one per-level index into a fixed-width field of a BigInt
+   path; that width MUST exceed any node's actual size or `seq`/`rseq`/`slice`
+   silently truncate at the field's max.
+
+   The bug: the field was `ceil(log2 branching-factor)` bits (6 for bf 64), so the
+   last index of an oversized leaf was masked (`199 & 63 = 7`) and iteration
+   stopped early — a 65-key MST leaf iterated to ONE element. The field is now a
+   fixed 32 bits/level (like the JVM's int[]-per-level path). This guards every
+   read direction across sizes that empirically produce oversized nodes."
+  (:require [cljs.test :as test :refer-macros [is deftest]]
+            [org.replikativ.persistent-sorted-set :as set]
+            [org.replikativ.persistent-sorted-set.boundary :as bnd]))
+
+(deftest mst-oversized-node-full-iteration
+  (let [mst {:comparator compare :branching-factor 64 :boundary (bnd/mst-boundary 6)}]
+    ;; sizes span below bf (controls) and well above it (oversized-node triggers:
+    ;; 65/100/130/200 build a single >bf leaf; 300/1000 build multi-node MST trees).
+    (doseq [n [1 8 63 64 65 100 130 200 300 1000]]
+      (let [elems (range n)
+            s     (into (set/sorted-set* mst) elems)]
+        (is (= n (count s))                  (str "count, n=" n))
+        (is (= (seq elems) (seq s))          (str "seq, n=" n))
+        (is (= (seq (reverse elems)) (rseq s)) (str "rseq, n=" n))
+        (when (>= n 64)
+          (is (= (range 10 30) (set/slice s 10 29)) (str "slice [10,29], n=" n))
+          (is (= (range (- n 5) n) (set/slice s (- n 5) (dec n)))
+              (str "slice tail, n=" n)))))))


### PR DESCRIPTION
## The bug (cljs only, silent data loss on read)

The cljs iterator (`btset.cljs`) represents a cursor as a **path** — the child-index at each tree level — packed into a single `BigInt`, one fixed-width field per level. The width was `bits-per-level = ceil(log2 branching-factor)` (6 bits for bf 64). `path-get`/`path-set` shift+mask by that width.

That is **exactly right for a count B-tree** (a node never exceeds `branching-factor` — it splits at bf, so indices 0…63 fit in 6 bits). But an **MST content-defined boundary** (`{:boundary (mst-boundary lzpl)}`) splits a node only at *boundary keys* (hashes with ≥ lzpl leading zeros), **not by size** — so with no boundary key in a range, a node grows well past `branching-factor`. Its last index (e.g. 199) then overflows the 6-bit field: `path-set` records it but `path-get` masks it back (`199 & 63 = 7`), the iterator's end-path collapses, and **`seq`/`rseq`/`slice` silently truncate**.

Measured exactly — `seq = ((leafkeys − 1) & 63) + 1`:

| set size (single MST leaf) | seq before | after |
|---|---|---|
| 64 | 64 | 64 |
| **65** | **1** | 65 |
| 100 | 36 | 100 |
| 200 | 8 | 200 |
| 300 (multi-node) | 172 | 300 |

The JVM is unaffected — it stores the path as an `int[]` (one full int per level), no bit-packing.

## The fix

Set `bits-per-level` to a fixed **32 bits/level** (matching the JVM's int-per-level path), so a per-level index never overflows for any realistically sized node (a node with > 2³² entries is physically impossible). All path ops derive shift/mask from this one value, so they widen consistently; path-ordering and the ± 1n carry are width-independent; only a single extracted level index is converted to a JS `Number` and it's ≤ 2³²−1 (within 2⁵³). Content-addressing is untouched.

## Verification

- New cljs regression test `test.mst-iteration`: `seq`/`rseq`/`slice`/`count` fully round-trip MST sets across sizes 1…1000 (covering single oversized leaves and multi-node MST trees).
- **cljs**: 135 tests / 1732 assertions, 0 failures.
- **JVM**: 196 tests / 52485 assertions, 0 failures (unchanged — fix is cljs-only).

Impact: any cljs consumer using the MST boundary (e.g. yggrasil's convergent CRDTs default to it) would silently lose elements on read for sets larger than one node. This restores correctness.