### PR TITLE
fix(btset cljs): forward-declare disjoin to silence :undeclared-var

### DIFF
--- a/src-clojure/org/replikativ/persistent_sorted_set/btset.cljs
+++ b/src-clojure/org/replikativ/persistent_sorted_set/btset.cljs
@@ -95,7 +95,9 @@
                             (conj! as (branch/address node i)))
                      [(persistent! cs) (persistent! as)]))))))
 
-(declare mst-merge-with mst-remove-content)
+;; `disjoin` (defined below) is used by the MST replace path above it — forward-
+;; declare it so cljs's single-pass analyzer doesn't warn :undeclared-var.
+(declare mst-merge-with mst-remove-content disjoin)
 
 (defn- mst-merge-with
   "Combine two same-level nodes whose separating (removed) boundary is gone. The junction —


### PR DESCRIPTION
ClojureScript's single-pass analyzer warns `:undeclared-var` on `btset.cljs`: the MST replace path (~line 289) uses `disjoin`, which is `defn`'d further down (~line 324). On the JVM (multi-pass) this is fine; on cljs it's a forward reference.

Fix: add `disjoin` to the existing `(declare …)` near the top.

This warning surfaces in every downstream cljs build that uses PSS (datahike, yggdrasil, spindel), so clearing it at the source cleans those up too.

## Verification
`:node-tests` cljs build: `Build completed. (140 files, 1 compiled, 0 warnings, 5.22s)` — the `disjoin` warning is gone, no new warnings. JVM is unaffected (the `declare` is a no-op there).